### PR TITLE
DataUsersDictとDataCollectorsDictを実装

### DIFF
--- a/tests/pamiq_core/data/test_container.py
+++ b/tests/pamiq_core/data/test_container.py
@@ -1,0 +1,80 @@
+import pytest
+
+from pamiq_core.data.buffer import BufferData, DataBuffer, StepData
+from pamiq_core.data.container import DataCollectorsDict, DataUsersDict
+from pamiq_core.data.interface import DataCollector, DataUser
+
+
+class MockDataBuffer(DataBuffer):
+    def __init__(self, collecting_data_names: list[str], max_size: int) -> None:
+        super().__init__(collecting_data_names, max_size)
+        self.data: list[StepData] = []
+
+    def add(self, step_data: StepData) -> None:
+        if len(self.data) < self.max_size:
+            self.data.append(step_data)
+
+    def get_data(self) -> BufferData:
+        return {
+            name: [d[name] for d in self.data] for name in self._collecting_data_names
+        }
+
+
+class TestDataUsersDict:
+    @pytest.fixture
+    def buffers(self) -> dict[str, MockDataBuffer]:
+        return {
+            "main": MockDataBuffer(["state"], 100),
+            "sub": MockDataBuffer(["action"], 100),
+        }
+
+    def test_from_data_buffers_dict(self, buffers: dict[str, MockDataBuffer]):
+        users_dict = DataUsersDict.from_data_buffers(buffers)
+        assert len(users_dict) == 2
+        assert all(isinstance(v, DataUser) for v in users_dict.values())
+        assert set(users_dict.keys()) == {"main", "sub"}
+
+    def test_from_data_buffers_kwargs(self, buffers: dict[str, MockDataBuffer]):
+        users_dict = DataUsersDict.from_data_buffers(**buffers)
+        assert len(users_dict) == 2
+        assert all(isinstance(v, DataUser) for v in users_dict.values())
+        assert set(users_dict.keys()) == {"main", "sub"}
+
+    def test_from_data_buffers_mixed(self, buffers: dict[str, MockDataBuffer]):
+        buffer3 = MockDataBuffer(["reward"], 100)
+        users_dict = DataUsersDict.from_data_buffers(buffers, extra=buffer3)
+        assert len(users_dict) == 3
+        assert all(isinstance(v, DataUser) for v in users_dict.values())
+        assert set(users_dict.keys()) == {"main", "sub", "extra"}
+
+    def test_get_data_collectors(self, buffers: dict[str, MockDataBuffer]):
+        users_dict = DataUsersDict.from_data_buffers(buffers)
+        collectors_dict = users_dict.get_data_collectors()
+
+        assert isinstance(collectors_dict, DataCollectorsDict)
+        assert len(collectors_dict) == 2
+        assert all(isinstance(v, DataCollector) for v in collectors_dict.values())
+        assert set(collectors_dict.keys()) == {"main", "sub"}
+
+
+class TestDataCollectorsDict:
+    @pytest.fixture
+    def collectors_dict(self) -> DataCollectorsDict:
+        buffer1 = MockDataBuffer(["state"], 100)
+        buffer2 = MockDataBuffer(["action"], 100)
+        users_dict = DataUsersDict.from_data_buffers(main=buffer1, sub=buffer2)
+        return users_dict.get_data_collectors()
+
+    def test_acquire_success(self, collectors_dict: DataCollectorsDict):
+        collector = collectors_dict.acquire("main")
+        assert isinstance(collector, DataCollector)
+        assert collector == collectors_dict["main"]
+
+    def test_acquire_already_acquired(self, collectors_dict: DataCollectorsDict):
+        collectors_dict.acquire("main")
+        with pytest.raises(KeyError, match="'main' is already acquired"):
+            collectors_dict.acquire("main")
+
+    def test_acquire_not_found(self, collectors_dict: DataCollectorsDict):
+        with pytest.raises(KeyError, match="'unknown' not found"):
+            collectors_dict.acquire("unknown")


### PR DESCRIPTION
# Pull Request

## 内容

#22 #19 旧AMI SystemのDataCollectorsDict, DataUsersDictを移植しました。
現在の User / Collectorの実装に合わせて修正しているほか、状態保存機能はまだ実装していません。

DataUsersDictがDataCollectorsDictを生成し、TrainingThreadからInferenceThreadに共有する想定です。


<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
