### PR TITLE
feat: add `PersistentStateMixin` and `StateStore`  for save and load states

### DIFF
--- a/src/pamiq_core/state_persistence.py
+++ b/src/pamiq_core/state_persistence.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+from pathlib import Path
+
+
+class PersistentStateMixin:
+    """Mixin class for objects with persistable state.
+
+    This mixin provides the ability to save and load state. Classes that
+    inherit from this mixin must implement `save_state()` and
+    `load_state()`.
+    """
+
+    def save_state(self, path: Path):
+        """Save state to `path`"""
+        pass
+
+    def load_state(self, path: Path):
+        """Load state from `path`"""
+        pass
+
+
+class StateStore:
+    """Class to save and load multiple persistable objects at once.
+
+    This class saves the state of each registered object to the
+    specified directory. It is also possible to restore the state from
+    the directory.
+    """
+
+    def __init__(
+        self, states_dir: Path, state_name_format: str = "%Y-%m-%d_%H-%M-%S,%f.state"
+    ) -> None:
+        """
+        Args:
+            states_dir: Root path to the directory where states are saved
+            state_name_format: Format for the subdirectory name (defaults to timestamp)
+        """
+        self.states_dir = Path(states_dir)
+        self.states_dir.mkdir(exist_ok=True)
+        self.state_name_format = state_name_format
+        self._registered_states = {}
+
+    def register(self, name: str, state: PersistentStateMixin) -> None:
+        """Register a persistable object with a unique name.
+
+        Args:
+            name: Unique name to identify the state
+            state: Object implementing PersistentStateMixin
+
+        Raises:
+            KeyError: If `name` is already registered
+        """
+        if name in self._registered_states:
+            raise KeyError(f"State with name '{name}' is already registered")
+        self._registered_states[name] = state
+
+    def save_state(self) -> Path:
+        """Save the all states of registered objects.
+
+        Returns:
+            Path: Path to the directory where the states are saved
+
+        Raises:
+            FileExistsError: If the directory (`states_path`) already exists (This only occurs if multiple attempts to create directories are at the same time)
+        """
+        state_path = self.states_dir / datetime.now().strftime(self.state_name_format)
+        state_path.mkdir()
+        for name, state in self._registered_states.items():
+            state.save_state(state_path / name)
+        return state_path
+
+    def load_state(self, state_path: Path) -> None:
+        """Restores the state from the `state_path` directory.
+
+        Args:
+            state_path: Path to the directory where the state is saved
+
+        Raises:
+            FileNotFoundError: If the specified path does not exist
+        """
+        if not state_path.exists():
+            raise FileNotFoundError(f"State path: '{state_path}' not found!")
+        for name, state in self._registered_states.items():
+            state.load_state(state_path / name)

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -75,13 +75,7 @@ class TestStateStore:
             store.load_state(tmp_path / "non_existent_folder")
 
         # test for normal case
-        (tmp_path / "mock_state_1").mkdir()
-        (tmp_path / "mock_state_2").mkdir()
         store.load_state(tmp_path)
-        # assert parent_mock.mock_calls == [
-        #     mocker.call.mock_state_1.load_state(tmp_path / "mock_state_1"),
-        #     mocker.call.mock_state_2.load_state(tmp_path / "mock_state_2"),
-        # ]  # test: `load_state()`` is called for each registered state
 
         mock_state_1.load_state.assert_called_once_with(tmp_path / "mock_state_1")
         mock_state_2.load_state.assert_called_once_with(tmp_path / "mock_state_2")

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -86,9 +86,5 @@ class TestStateStore:
         #     mocker.call.mock_state_2.load_state(tmp_path / "mock_state_2"),
         # ]  # test: `load_state()`` is called for each registered state
 
-        assert mock_state_1.load_state.assert_called_once_with(
-            tmp_path / "mock_state_1"
-        )
-        assert mock_state_2.load_state.assert_called_once_with(
-            tmp_path / "mock_state_2"
-        )
+        mock_state_1.load_state.assert_called_once_with(tmp_path / "mock_state_1")
+        mock_state_2.load_state.assert_called_once_with(tmp_path / "mock_state_2")

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -54,7 +54,16 @@ class TestStateStore:
         class FakeDatetime(datetime):
             @classmethod
             def now(cls, tz: tzinfo | None = None):
-                return fixed_test_time
+                return cls(
+                    year=fixed_test_time.year,
+                    month=fixed_test_time.month,
+                    day=fixed_test_time.day,
+                    hour=fixed_test_time.hour,
+                    minute=fixed_test_time.minute,
+                    second=fixed_test_time.second,
+                    microsecond=fixed_test_time.microsecond,
+                    tzinfo=fixed_test_time.tzinfo,
+                )
 
         mocker.patch("pamiq_core.state_persistence.datetime", FakeDatetime)
 

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -56,10 +56,8 @@ class TestStateStore:
 
         assert state_path.exists()  # test: folder is created
         assert state_path == Path(tmp_path / "2025-02-27_12-00-00,000000.state")
-        assert parent_mock.mock_calls == [
-            mocker.call.mock_state_1.save_state(state_path / "mock_state_1"),
-            mocker.call.mock_state_2.save_state(state_path / "mock_state_2"),
-        ]  # test: `save_state()` is called for each registered state
+        mock_state_1.save_state.assert_called_once_with(state_path / "mock_state_1")
+        mock_state_2.save_state.assert_called_once_with(state_path / "mock_state_2")
 
         # expect error in `Path.mkdir`:
         with pytest.raises(FileExistsError):

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -79,7 +79,6 @@ class TestStateStore:
         store.register("mock_state_2", mock_state_2)
 
         # test for exceptional case
-        mocker.patch("pamiq_core.state_persistence.Path.exists", return_value=False)
         with pytest.raises(FileNotFoundError):
             store.load_state(tmp_path / "non_existent_folder")
 

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -1,0 +1,102 @@
+import shutil
+import unittest
+from datetime import datetime, tzinfo
+from pathlib import Path
+
+import pytest
+
+from pamiq_core.state_persistence import PersistentStateMixin, StateStore
+
+
+class TestStateStore:
+    state_1 = PersistentStateMixin()
+    state_2 = PersistentStateMixin()
+
+    def test_register(self, tmp_path):
+        store = StateStore(states_dir=tmp_path)
+        store.register("state_1", self.state_1)
+
+        assert store._registered_states == {"state_1": self.state_1}
+
+        store.register("state_2", self.state_2)
+
+        assert store._registered_states == {
+            "state_1": self.state_1,
+            "state_2": self.state_2,
+        }
+
+    def test_register_name_already_used_error(self, tmp_path):
+        store = StateStore(states_dir=tmp_path)
+        store.register("same_name", self.state_1)
+
+        # should raise KeyError:
+        with pytest.raises(KeyError):
+            store.register("same_name", self.state_2)
+
+    def test_save_state(self, tmp_path, mocker):
+        # prepare mock objects
+        parent_mock = mocker.Mock()
+        mock_state_1 = mocker.Mock(spec=PersistentStateMixin)
+        mock_state_2 = mocker.Mock(spec=PersistentStateMixin)
+        parent_mock.attach_mock(mock_state_1, "mock_state_1")
+        parent_mock.attach_mock(mock_state_2, "mock_state_2")
+
+        # configure StateStore object
+        store = StateStore(states_dir=tmp_path)
+        store.register("mock_state_1", mock_state_1)
+        store.register("mock_state_2", mock_state_2)
+
+        # Mock store.datetime.now so that tests do not depend on the current time
+        fixed_test_time = datetime(2025, 2, 27, 12, 0, 0)
+
+        # Cannot directly mock `datetime.now` because it is a built-in method
+        # Instead, create a subclass of `datetime` and mock `now` method
+        class FakeDatetime(datetime):
+            @classmethod
+            def now(cls, tz: tzinfo | None = None):
+                return fixed_test_time
+
+        mocker.patch("pamiq_core.state_persistence.datetime", FakeDatetime)
+
+        state_path = store.save_state()
+
+        assert state_path.exists()  # test: folder is created
+        assert state_path == Path(tmp_path / "2025-02-27_12-00-00,000000.state")
+        assert parent_mock.mock_calls == [
+            mocker.call.mock_state_1.save_state(state_path / "mock_state_1"),
+            mocker.call.mock_state_2.save_state(state_path / "mock_state_2"),
+        ]  # test: `save_state()` is called for each registered state
+
+        # expect error in `Path.mkdir`:
+        with pytest.raises(FileExistsError):
+            store.save_state()
+
+    def test_load_state(self, tmp_path, mocker):
+        # prepare mock objects
+        parent_mock = mocker.Mock()
+        mock_state_1 = mocker.Mock(spec=PersistentStateMixin)
+        mock_state_2 = mocker.Mock(spec=PersistentStateMixin)
+        parent_mock.attach_mock(mock_state_1, "mock_state_1")
+        parent_mock.attach_mock(mock_state_2, "mock_state_2")
+
+        # configure StateStore object
+        store = StateStore(states_dir=tmp_path)
+        store.register("mock_state_1", mock_state_1)
+        store.register("mock_state_2", mock_state_2)
+
+        # test for exceptional case
+        mocker.patch("pamiq_core.state_persistence.Path.exists", return_value=False)
+        with pytest.raises(FileNotFoundError):
+            store.load_state(tmp_path / "non_existent_folder")
+
+        # test for normal case
+        mocker.patch("pamiq_core.state_persistence.Path.exists", return_value=True)
+        store.load_state(tmp_path)
+        assert parent_mock.mock_calls == [
+            mocker.call.mock_state_1.load_state(tmp_path / "mock_state_1"),
+            mocker.call.mock_state_2.load_state(tmp_path / "mock_state_2"),
+        ]  # test: `load_state()`` is called for each registered state
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -78,7 +78,8 @@ class TestStateStore:
             store.load_state(tmp_path / "non_existent_folder")
 
         # test for normal case
-        mocker.patch("pamiq_core.state_persistence.Path.exists", return_value=True)
+        (tmp_path / "mock_state_1").mkdir()
+        (tmp_path / "mock_state_2").mkdir()
         store.load_state(tmp_path)
         assert parent_mock.mock_calls == [
             mocker.call.mock_state_1.load_state(tmp_path / "mock_state_1"),

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -1,5 +1,4 @@
 import shutil
-import unittest
 from datetime import datetime, tzinfo
 from pathlib import Path
 

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -34,11 +34,8 @@ class TestStateStore:
 
     def test_save_state(self, tmp_path, mocker):
         # prepare mock objects
-        parent_mock = mocker.Mock()
         mock_state_1 = mocker.Mock(spec=PersistentStateMixin)
         mock_state_2 = mocker.Mock(spec=PersistentStateMixin)
-        parent_mock.attach_mock(mock_state_1, "mock_state_1")
-        parent_mock.attach_mock(mock_state_2, "mock_state_2")
 
         # configure StateStore object
         store = StateStore(states_dir=tmp_path)

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -62,11 +62,8 @@ class TestStateStore:
 
     def test_load_state(self, tmp_path, mocker):
         # prepare mock objects
-        # parent_mock = mocker.Mock()
         mock_state_1 = mocker.Mock(spec=PersistentStateMixin)
         mock_state_2 = mocker.Mock(spec=PersistentStateMixin)
-        # parent_mock.attach_mock(mock_state_1, "mock_state_1")
-        # parent_mock.attach_mock(mock_state_2, "mock_state_2")
 
         # configure StateStore object
         store = StateStore(states_dir=tmp_path)

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -44,7 +44,7 @@ class TestStateStore:
 
         # Mock store.datetime.now so that tests do not depend on the current time
         fixed_test_time = datetime(2025, 2, 27, 12, 0, 0)
-        
+
         mock_dt = mocker.Mock(datetime)
         mock_dt.now.return_value = fixed_test_time
         mocker.patch("pamiq_core.state_persistence.datetime", mock_dt)
@@ -62,11 +62,11 @@ class TestStateStore:
 
     def test_load_state(self, tmp_path, mocker):
         # prepare mock objects
-        parent_mock = mocker.Mock()
+        # parent_mock = mocker.Mock()
         mock_state_1 = mocker.Mock(spec=PersistentStateMixin)
         mock_state_2 = mocker.Mock(spec=PersistentStateMixin)
-        parent_mock.attach_mock(mock_state_1, "mock_state_1")
-        parent_mock.attach_mock(mock_state_2, "mock_state_2")
+        # parent_mock.attach_mock(mock_state_1, "mock_state_1")
+        # parent_mock.attach_mock(mock_state_2, "mock_state_2")
 
         # configure StateStore object
         store = StateStore(states_dir=tmp_path)
@@ -81,9 +81,14 @@ class TestStateStore:
         (tmp_path / "mock_state_1").mkdir()
         (tmp_path / "mock_state_2").mkdir()
         store.load_state(tmp_path)
-        assert parent_mock.mock_calls == [
-            mocker.call.mock_state_1.load_state(tmp_path / "mock_state_1"),
-            mocker.call.mock_state_2.load_state(tmp_path / "mock_state_2"),
-        ]  # test: `load_state()`` is called for each registered state
+        # assert parent_mock.mock_calls == [
+        #     mocker.call.mock_state_1.load_state(tmp_path / "mock_state_1"),
+        #     mocker.call.mock_state_2.load_state(tmp_path / "mock_state_2"),
+        # ]  # test: `load_state()`` is called for each registered state
 
-
+        assert mock_state_1.load_state.assert_called_once_with(
+            tmp_path / "mock_state_1"
+        )
+        assert mock_state_2.load_state.assert_called_once_with(
+            tmp_path / "mock_state_2"
+        )

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -47,24 +47,10 @@ class TestStateStore:
 
         # Mock store.datetime.now so that tests do not depend on the current time
         fixed_test_time = datetime(2025, 2, 27, 12, 0, 0)
-
-        # Cannot directly mock `datetime.now` because it is a built-in method
-        # Instead, create a subclass of `datetime` and mock `now` method
-        class FakeDatetime(datetime):
-            @classmethod
-            def now(cls, tz: tzinfo | None = None):
-                return cls(
-                    year=fixed_test_time.year,
-                    month=fixed_test_time.month,
-                    day=fixed_test_time.day,
-                    hour=fixed_test_time.hour,
-                    minute=fixed_test_time.minute,
-                    second=fixed_test_time.second,
-                    microsecond=fixed_test_time.microsecond,
-                    tzinfo=fixed_test_time.tzinfo,
-                )
-
-        mocker.patch("pamiq_core.state_persistence.datetime", FakeDatetime)
+        
+        mock_dt = mocker.Mock(datetime)
+        mock_dt.now.return_value = fixed_test_time
+        mocker.patch("pamiq_core.state_persistence.datetime", mock_dt)
 
         state_path = store.save_state()
 

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -106,5 +106,3 @@ class TestStateStore:
         ]  # test: `load_state()`` is called for each registered state
 
 
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
# Pull Request

## 内容

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->
#32 
state の保存と読み込みのため、 `PersistentStateMixin` と `StateStore` を実装。


<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?
  - [x] `make run -k` を後で実行するべし

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

- `PersistentStateMixin` は ABC にせず、 `save_state()` と `load_state()` は `@abstractmethod` にすることはしませんでした。
  - 実装を強制するなら ABC のほうが良いと思いましたが、 https://github.com/MLShukai/ami/blob/main/ami/checkpointing/save_and_load_state_mixin.py を参考に、こちらに揃えました。
  - save や loda せずにモデルをとりあえず試しに動かすとかそういうこともあるのか？ なら強制しないほうがいいのか？ と想像して、今の実装になっています。
- `StateStore.save_state()` では、`mkdir()` （67行目）の引数に `exist_ok` は書かず、フォルダが存在していたらエラーになるようにしてあります。
  - 現実的には、同じ timestamp 内で2度実行されないとエラーにならないのでどちらでもいい気がしますが、ファイルが同じフォルダに混ざる危険はしれたほうが良いかと思い、そうしてあります。（正確には、Geson さんからもらったコードから変更していません）
