### PR TITLE
DataBufferクラスが内部に保持するデータをGenericsでtyping

### DIFF
--- a/src/pamiq_core/data/buffer.py
+++ b/src/pamiq_core/data/buffer.py
@@ -1,14 +1,13 @@
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Any
 
 from pamiq_core.state_persistence import PersistentStateMixin
 
-type StepData = Mapping[str, Any]
-type BufferData = Mapping[str, Sequence[Any]]
+type StepData[T] = Mapping[str, T]
+type BufferData[T] = Mapping[str, Sequence[T]]
 
 
-class DataBuffer(ABC, PersistentStateMixin):
+class DataBuffer[T](ABC, PersistentStateMixin):
     """Interface for managing experience data collected during system
     execution.
 
@@ -45,7 +44,7 @@ class DataBuffer(ABC, PersistentStateMixin):
         return self._max_size
 
     @abstractmethod
-    def add(self, step_data: StepData) -> None:
+    def add(self, step_data: StepData[T]) -> None:
         """Adds a new data sample to the buffer.
 
         Args:
@@ -55,7 +54,7 @@ class DataBuffer(ABC, PersistentStateMixin):
         ...
 
     @abstractmethod
-    def get_data(self) -> BufferData:
+    def get_data(self) -> BufferData[T]:
         """Retrieves all stored data from the buffer.
 
         Returns:

--- a/src/pamiq_core/data/container.py
+++ b/src/pamiq_core/data/container.py
@@ -53,7 +53,10 @@ class DataUsersDict(UserDict[str, DataUser[Any]], PersistentStateMixin):
 
     @classmethod
     def from_data_buffers(
-        cls, dict: Mapping[str, DataBuffer] | None = None, /, **kwds: DataBuffer
+        cls,
+        dict: Mapping[str, DataBuffer[Any]] | None = None,
+        /,
+        **kwds: DataBuffer[Any],
     ) -> Self:
         """Creates a DataUsersDict from a mapping of data buffers.
 
@@ -64,7 +67,7 @@ class DataUsersDict(UserDict[str, DataUser[Any]], PersistentStateMixin):
         Returns:
             New DataUsersDict instance with users created from buffers.
         """
-        data: dict[str, DataBuffer] = {}
+        data: dict[str, DataBuffer[Any]] = {}
         if dict is not None:
             data.update(dict)
         if len(kwds) > 0:


### PR DESCRIPTION
# Pull Request

## 内容

データバッファはコンテナであり、内部に保持するデータの型が明示されるべきと判断し、DataBufferをGenericsにしました。

また、 DataUserやDataCollectorが DataBufferをGenericsとして受け取っていたのですが、機能的に無意味だったため削除しました。ただし、DataBufferがGenerics化したので型変数は使用しています

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [ ] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
