### PR TITLE
RandomReplacementBufferを実装

### DIFF
--- a/src/pamiq_core/data/__init__.py
+++ b/src/pamiq_core/data/__init__.py
@@ -1,6 +1,6 @@
 from .buffer import BufferData, DataBuffer, StepData
 from .container import DataCollectorsDict, DataUsersDict
-from .implementations import SequentialBuffer
+from .implementations import RandomReplacementBuffer, SequentialBuffer
 from .interface import DataCollector, DataUser
 
 __all__ = [
@@ -12,4 +12,5 @@ __all__ = [
     "DataCollectorsDict",
     "DataUsersDict",
     "SequentialBuffer",
+    "RandomReplacementBuffer",
 ]

--- a/src/pamiq_core/data/implementations/__init__.py
+++ b/src/pamiq_core/data/implementations/__init__.py
@@ -1,3 +1,4 @@
+from .random_replacement_buffer import RandomReplacementBuffer
 from .sequential_buffer import SequentialBuffer
 
-__all__ = ["SequentialBuffer"]
+__all__ = ["SequentialBuffer", "RandomReplacementBuffer"]

--- a/src/pamiq_core/data/implementations/random_replacement_buffer.py
+++ b/src/pamiq_core/data/implementations/random_replacement_buffer.py
@@ -124,7 +124,7 @@ class RandomReplacementBuffer[T](DataBuffer[T]):
         size: int | None = None
         for name in self.collecting_data_names:
             with open(path / f"{name}.pkl", "rb") as f:
-                obj = pickle.load(f)
+                obj = list(pickle.load(f))
             if size is None:
                 size = len(obj)
             if size != len(obj):

--- a/src/pamiq_core/data/implementations/random_replacement_buffer.py
+++ b/src/pamiq_core/data/implementations/random_replacement_buffer.py
@@ -12,6 +12,9 @@ class RandomReplacementBuffer[T](DataBuffer[T]):
 
     This buffer keeps track of collected data and, when full, randomly
     replaces existing elements based on a configurable probability.
+
+    See this page to learn more properties:
+        https://zenn.dev/gesonanko/scraps/b581e75bfd9f3e
     """
 
     def __init__(

--- a/src/pamiq_core/data/implementations/random_replacement_buffer.py
+++ b/src/pamiq_core/data/implementations/random_replacement_buffer.py
@@ -127,7 +127,7 @@ class RandomReplacementBuffer[T](DataBuffer[T]):
         size: int | None = None
         for name in self.collecting_data_names:
             with open(path / f"{name}.pkl", "rb") as f:
-                obj = list(pickle.load(f))
+                obj = list(pickle.load(f))[: self.max_size]
             if size is None:
                 size = len(obj)
             if size != len(obj):

--- a/src/pamiq_core/data/implementations/random_replacement_buffer.py
+++ b/src/pamiq_core/data/implementations/random_replacement_buffer.py
@@ -1,0 +1,138 @@
+import pickle
+import random
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import override
+
+from ..buffer import DataBuffer, StepData
+
+
+class RandomReplacementBuffer[T](DataBuffer[T]):
+    """Buffer implementation that randomly replaces elements when full.
+
+    This buffer keeps track of collected data and, when full, randomly
+    replaces existing elements based on a configurable probability.
+    """
+
+    def __init__(
+        self,
+        collecting_data_names: Iterable[str],
+        max_size: int,
+        replace_probability: float = 1.0,
+    ) -> None:
+        """Initialize a RandomReplacementBuffer.
+
+        Args:
+            collecting_data_names: Names of data fields to collect.
+            max_size: Maximum number of data points to store.
+            replace_probability: Probability of replacing an existing element when buffer is full.
+                Must be between 0.0 and 1.0 inclusive. Default is 1.0 (always replace).
+
+        Raises:
+            ValueError: If replace_probability is not between 0.0 and 1.0 inclusive.
+        """
+        super().__init__(collecting_data_names, max_size)
+
+        if not (1.0 >= replace_probability >= 0.0):
+            raise ValueError(
+                "replace_probability must be between 0.0 and 1.0 inclusive"
+            )
+
+        self._lists_dict: dict[str, list[T]] = {
+            name: [] for name in collecting_data_names
+        }
+
+        self._replace_probability = replace_probability
+        self._current_size = 0
+
+    @property
+    def is_full(self) -> bool:
+        """Check if the buffer has reached its maximum capacity.
+
+        Returns:
+            True if the buffer is full, False otherwise.
+        """
+        return self._current_size >= self.max_size
+
+    @override
+    def add(self, step_data: StepData[T]) -> None:
+        """Add a new data sample to the buffer.
+
+        If the buffer is full, the new data may replace an existing entry
+        based on the configured replacement probability.
+
+        Args:
+            step_data: Dictionary containing data for one step. Must contain
+                all fields specified in collecting_data_names.
+
+        Raises:
+            KeyError: If a required data field is missing from step_data.
+        """
+        for name in self.collecting_data_names:
+            if name not in step_data:
+                raise KeyError(f"Required data '{name}' not found in step_data")
+
+        if self.is_full:
+            if random.random() > self._replace_probability:
+                return
+            replace_index = random.randint(0, self.max_size - 1)
+            for name in self.collecting_data_names:
+                self._lists_dict[name][replace_index] = step_data[name]
+        else:
+            for name in self.collecting_data_names:
+                self._lists_dict[name].append(step_data[name])
+            self._current_size += 1
+
+    @override
+    def get_data(self) -> Mapping[str, list[T]]:
+        """Retrieve all stored data from the buffer.
+
+        Returns:
+            Dictionary mapping data field names to lists of their values.
+            Returns a copy of the internal data to prevent modification.
+        """
+        return {name: data.copy() for name, data in self._lists_dict.items()}
+
+    @override
+    def save_state(self, path: Path) -> None:
+        """Save the buffer state to the specified path.
+
+        Creates a directory at the given path and saves each data list as a
+        separate pickle file.
+
+        Args:
+            path: Directory path where to save the buffer state.
+        """
+        path.mkdir()
+        for name, data in self._lists_dict.items():
+            with open(path / f"{name}.pkl", "wb") as f:
+                pickle.dump(data, f)
+
+    @override
+    def load_state(self, path: Path) -> None:
+        """Load the buffer state from the specified path.
+
+        Loads data lists from pickle files in the given directory.
+
+        Args:
+            path: Directory path from where to load the buffer state.
+
+        Raises:
+            ValueError: If loaded data lists have inconsistent lengths.
+        """
+        lists_dict: dict[str, list[T]] = {}
+        size: int | None = None
+        for name in self.collecting_data_names:
+            with open(path / f"{name}.pkl", "rb") as f:
+                obj = pickle.load(f)
+            if size is None:
+                size = len(obj)
+            if size != len(obj):
+                raise ValueError("Inconsistent list lengths in loaded data")
+            lists_dict[name] = obj
+
+        self._lists_dict = lists_dict
+        if size is None:
+            self._current_size = 0
+        else:
+            self._current_size = size

--- a/tests/pamiq_core/data/implementations/test_random_replacement_buffer.py
+++ b/tests/pamiq_core/data/implementations/test_random_replacement_buffer.py
@@ -1,0 +1,200 @@
+import pickle
+import random
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from pamiq_core.data.implementations.random_replacement_buffer import (
+    RandomReplacementBuffer,
+)
+
+
+class TestRandomReplacementBuffer:
+    """Test suite for RandomReplacementBuffer class."""
+
+    @pytest.fixture
+    def buffer(self) -> RandomReplacementBuffer[Any]:
+        """Fixture providing a standard RandomReplacementBuffer for tests."""
+        return RandomReplacementBuffer(["state", "action", "reward"], 5)
+
+    def test_init(self):
+        """Test RandomReplacementBuffer initialization with various
+        parameters."""
+        # Test with standard parameters
+        data_names = ["state", "action", "reward"]
+        max_size = 10
+        buffer = RandomReplacementBuffer(data_names, max_size)
+
+        assert buffer.max_size == max_size
+        assert buffer.collecting_data_names == set(data_names)
+        assert buffer._replace_probability == 1.0
+        assert buffer._current_size == 0
+        assert not buffer.is_full
+
+        # Test with custom replace probability
+        buffer = RandomReplacementBuffer(data_names, max_size, replace_probability=0.5)
+        assert buffer._replace_probability == 0.5
+
+        # Test with invalid replace probability
+        with pytest.raises(ValueError):
+            RandomReplacementBuffer(data_names, max_size, replace_probability=-0.1)
+
+        with pytest.raises(ValueError):
+            RandomReplacementBuffer(data_names, max_size, replace_probability=1.1)
+
+    def test_add_and_get_data(self, buffer: RandomReplacementBuffer[Any]):
+        """Test adding data to the buffer and retrieving it."""
+        # Sample data
+        sample1 = {"state": [1.0, 0.0], "action": 1, "reward": 0.5}
+        sample2 = {"state": [0.0, 1.0], "action": 0, "reward": -0.5}
+
+        # Add data
+        buffer.add(sample1)
+
+        # Check data retrieval after adding one sample
+        data = buffer.get_data()
+        assert data["state"] == [[1.0, 0.0]]
+        assert data["action"] == [1]
+        assert data["reward"] == [0.5]
+        assert buffer._current_size == 1
+
+        # Add another sample
+        buffer.add(sample2)
+
+        # Check data retrieval after adding second sample
+        data = buffer.get_data()
+        assert data["state"] == [[1.0, 0.0], [0.0, 1.0]]
+        assert data["action"] == [1, 0]
+        assert data["reward"] == [0.5, -0.5]
+        assert buffer._current_size == 2
+
+    def test_is_full_property(self):
+        """Test the is_full property correctly reports buffer fullness."""
+        buffer = RandomReplacementBuffer(["value"], 3)
+
+        assert not buffer.is_full
+
+        # Fill the buffer
+        for i in range(3):
+            buffer.add({"value": i})
+
+        assert buffer.is_full
+
+    def test_replacement_when_full(self, monkeypatch):
+        """Test the random replacement behavior when buffer is full."""
+        # Create a small buffer
+        buffer = RandomReplacementBuffer(["value"], 2)
+
+        # Fill the buffer
+        buffer.add({"value": "A"})
+        buffer.add({"value": "B"})
+        assert buffer.is_full
+
+        # Mock random functions to get deterministic behavior
+        monkeypatch.setattr(random, "random", lambda: 0.0)  # Always below probability
+        monkeypatch.setattr(
+            random, "randint", lambda a, b: 0
+        )  # Always replace first element
+
+        # Add another item
+        buffer.add({"value": "C"})
+
+        # Check that first element was replaced
+        assert buffer.get_data()["value"] == ["C", "B"]
+
+    def test_skip_replacement(self, monkeypatch):
+        """Test that replacement is skipped based on probability."""
+        # Create a buffer with low replacement probability
+        buffer = RandomReplacementBuffer(["value"], 2, replace_probability=0.3)
+
+        # Fill the buffer
+        buffer.add({"value": "A"})
+        buffer.add({"value": "B"})
+        assert buffer.is_full
+
+        # Mock random to always be above the replacement probability
+        monkeypatch.setattr(random, "random", lambda: 0.9)
+
+        # Try to add another item
+        buffer.add({"value": "C"})
+
+        # Check that no replacement occurred
+        assert buffer.get_data()["value"] == ["A", "B"]
+
+    def test_missing_data_field(self, buffer: RandomReplacementBuffer[Any]):
+        """Test adding data with missing required fields raises KeyError."""
+        incomplete_data = {"state": [1.0, 0.0], "action": 1}  # Missing 'reward'
+
+        with pytest.raises(
+            KeyError, match="Required data 'reward' not found in step_data"
+        ):
+            buffer.add(incomplete_data)
+
+    def test_get_data_returns_copy(self, buffer: RandomReplacementBuffer[Any]):
+        """Test that get_data returns a copy that doesn't affect the internal
+        state."""
+        buffer.add({"state": [1.0], "action": 1, "reward": 0.5})
+
+        # Get data and modify it
+        data = buffer.get_data()
+        data["state"].append([2.0])
+
+        # Verify internal state is unchanged
+        new_data = buffer.get_data()
+        assert new_data["state"] == [[1.0]]
+        assert len(new_data["state"]) == 1
+
+    def test_save_and_load_state(
+        self, buffer: RandomReplacementBuffer[Any], tmp_path: Path
+    ):
+        """Test saving and loading the buffer state."""
+        # Add some data to the buffer
+        buffer.add({"state": [1.0, 0.0], "action": 1, "reward": 0.5})
+        buffer.add({"state": [0.0, 1.0], "action": 0, "reward": -0.5})
+
+        # Save state
+        save_path = tmp_path / "test_buffer"
+        buffer.save_state(save_path)
+
+        # Verify files were created
+        for name in buffer.collecting_data_names:
+            assert (save_path / f"{name}.pkl").exists()
+
+        # Create a new buffer and load state
+        new_buffer = RandomReplacementBuffer(
+            buffer.collecting_data_names, buffer.max_size
+        )
+        new_buffer.load_state(save_path)
+
+        # Check that loaded data matches original
+        original_data = buffer.get_data()
+        loaded_data = new_buffer.get_data()
+
+        assert loaded_data == original_data
+        assert new_buffer._current_size == buffer._current_size
+
+    def test_load_state_inconsistent_data(
+        self, buffer: RandomReplacementBuffer[Any], tmp_path: Path
+    ):
+        """Test loading state with inconsistent data lengths raises
+        ValueError."""
+        # Add some data to the buffer
+        buffer.add({"state": [1.0], "action": 1, "reward": 0.5})
+
+        # Save state
+        save_path = tmp_path / "test_buffer"
+        buffer.save_state(save_path)
+
+        # Corrupt one of the saved files
+        with open(save_path / "state.pkl", "wb") as f:
+            pickle.dump([[1.0], [2.0]], f)  # Different length
+
+        # Create a new buffer and try to load inconsistent state
+        new_buffer = RandomReplacementBuffer(
+            buffer.collecting_data_names, buffer.max_size
+        )
+        with pytest.raises(
+            ValueError, match="Inconsistent list lengths in loaded data"
+        ):
+            new_buffer.load_state(save_path)


### PR DESCRIPTION
# Pull Request

## 内容

#83 AMIのRandomDataBufferを移植しました。追加確率pが新たに加わっているほか、データの生存長の期待値などを求めたブログへのリンクを貼っています

https://zenn.dev/gesonanko/scraps/b581e75bfd9f3e

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
