### PR TITLE
DataBufferに 抽象メソッド`__len__`を追加

### DIFF
--- a/src/pamiq_core/data/buffer.py
+++ b/src/pamiq_core/data/buffer.py
@@ -62,3 +62,12 @@ class DataBuffer[T](ABC, PersistentStateMixin):
             Each sequence has the same length.
         """
         ...
+
+    @abstractmethod
+    def __len__(self) -> int:
+        """Returns the current number of samples in the buffer.
+
+        Returns:
+            int: The number of samples currently stored in the buffer.
+        """
+        ...

--- a/src/pamiq_core/data/impls/random_replacement_buffer.py
+++ b/src/pamiq_core/data/impls/random_replacement_buffer.py
@@ -97,6 +97,15 @@ class RandomReplacementBuffer[T](DataBuffer[T]):
         return {name: data.copy() for name, data in self._lists_dict.items()}
 
     @override
+    def __len__(self) -> int:
+        """Returns the current number of samples in the buffer.
+
+        Returns:
+            int: The number of samples currently stored in the buffer.
+        """
+        return self._current_size
+
+    @override
     def save_state(self, path: Path) -> None:
         """Save the buffer state to the specified path.
 

--- a/src/pamiq_core/data/impls/sequential_buffer.py
+++ b/src/pamiq_core/data/impls/sequential_buffer.py
@@ -29,6 +29,8 @@ class SequentialBuffer[T](DataBuffer[T]):
             name: deque(maxlen=max_size) for name in collecting_data_names
         }
 
+        self._current_size = 0
+
     @override
     def add(self, step_data: StepData[T]) -> None:
         """Add a new data sample to the buffer.
@@ -45,6 +47,9 @@ class SequentialBuffer[T](DataBuffer[T]):
                 raise KeyError(f"Required data '{name}' not found in step_data")
             self._queues_dict[name].append(step_data[name])
 
+        if self._current_size < self.max_size:
+            self._current_size += 1
+
     @override
     def get_data(self) -> dict[str, list[T]]:
         """Retrieve all stored data from the buffer.
@@ -54,6 +59,15 @@ class SequentialBuffer[T](DataBuffer[T]):
             Each list preserves the original insertion order.
         """
         return {name: list(queue) for name, queue in self._queues_dict.items()}
+
+    @override
+    def __len__(self) -> int:
+        """Returns the current number of samples in the buffer.
+
+        Returns:
+            int: The number of samples currently stored in the buffer.
+        """
+        return self._current_size
 
     @override
     def save_state(self, path: Path) -> None:

--- a/src/pamiq_core/data/interface.py
+++ b/src/pamiq_core/data/interface.py
@@ -160,6 +160,10 @@ class DataUser[T](PersistentStateMixin):
         with open(path / "timestamps.pkl", "rb") as f:
             self._timestamps = deque(pickle.load(f), maxlen=self._buffer.max_size)
 
+    def __len__(self) -> int:
+        """Returns the current number of samples in the buffer."""
+        return len(self._buffer)
+
 
 class DataCollector[T]:
     """A thread-safe collector for buffered data.

--- a/tests/pamiq_core/data/helpers.py
+++ b/tests/pamiq_core/data/helpers.py
@@ -1,6 +1,6 @@
 from collections import deque
 from collections.abc import Iterable
-from typing import Any
+from typing import Any, override
 
 from pamiq_core.data.buffer import BufferData, DataBuffer, StepData
 
@@ -18,14 +18,25 @@ class DataBufferImpl(DataBuffer):
             name: deque(maxlen=max_size) for name in collecting_data_names
         }
 
+        self._current_size = 0
+
+    @override
     def add(self, step_data: StepData) -> None:
         for name in self._collecting_data_names:
             if name not in step_data:
                 raise KeyError(f"Required data '{name}' not found in step_data")
             self._buffer[name].append(step_data[name])
 
+        if self._current_size < self.max_size:
+            self._current_size += 1
+
+    @override
     def get_data(self) -> BufferData:
         return self._buffer.copy()
+
+    @override
+    def __len__(self) -> int:
+        return self._current_size
 
 
 class MockDataBuffer(DataBuffer):
@@ -39,11 +50,17 @@ class MockDataBuffer(DataBuffer):
         super().__init__(collecting_data_names, max_size)
         self.data: list[StepData] = []
 
+    @override
     def add(self, step_data: StepData) -> None:
         if len(self.data) < self.max_size:
             self.data.append(step_data)
 
+    @override
     def get_data(self) -> BufferData:
         return {
             name: [d[name] for d in self.data] for name in self._collecting_data_names
         }
+
+    @override
+    def __len__(self) -> int:
+        return len(self.data)

--- a/tests/pamiq_core/data/impls/test_random_replacement_buffer.py
+++ b/tests/pamiq_core/data/impls/test_random_replacement_buffer.py
@@ -226,3 +226,13 @@ class TestRandomReplacementBuffer:
         for key in buffer.collecting_data_names:
             assert loaded_data[key] == original_data[key][:1]
         assert new_buffer._current_size == 1
+
+    def test_len(self, buffer: RandomReplacementBuffer[Any]):
+        """Test the __len__ method returns the correct buffer size."""
+        assert len(buffer) == 0
+
+        buffer.add({"state": [1.0, 0.0], "action": 1, "reward": 0.5})
+        assert len(buffer) == 1
+
+        buffer.add({"state": [0.0, 1.0], "action": 0, "reward": -0.5})
+        assert len(buffer) == 2

--- a/tests/pamiq_core/data/impls/test_sequential_buffer.py
+++ b/tests/pamiq_core/data/impls/test_sequential_buffer.py
@@ -114,3 +114,13 @@ class TestSequentialBuffer:
 
         for name in buffer.collecting_data_names:
             assert loaded_data[name] == original_data[name]
+
+    def test_len(self, buffer: SequentialBuffer):
+        """Test the __len__ method returns the correct buffer size."""
+        assert len(buffer) == 0
+
+        buffer.add({"state": [1.0, 0.0], "action": 1, "reward": 0.5})
+        assert len(buffer) == 1
+
+        buffer.add({"state": [0.0, 1.0], "action": 0, "reward": -0.5})
+        assert len(buffer) == 2

--- a/tests/pamiq_core/data/test_buffer.py
+++ b/tests/pamiq_core/data/test_buffer.py
@@ -13,6 +13,11 @@ class TestDataBuffer:
         """Test DataBuffer is PersistentStateMixin subclass."""
         assert issubclass(DataBuffer, PersistentStateMixin)
 
+    @pytest.mark.parametrize("name", ["__len__", "get_data", "add"])
+    def test_abstract_methods(self, name):
+        """Test that abstract method in DataBuffer."""
+        assert name in DataBuffer.__abstractmethods__
+
     def test_init(self):
         """Test DataBuffer initialization with valid parameters."""
         data_names = ["state", "action", "reward"]

--- a/tests/pamiq_core/data/test_interface.py
+++ b/tests/pamiq_core/data/test_interface.py
@@ -173,3 +173,11 @@ class TestDataUserAndCollector:
         # Verify loading timestamps
         assert data_user._timestamps is not prev_timestamps
         assert data_user._timestamps == prev_timestamps
+
+    def test_data_user_len(self, data_user: DataUser[MockDataBuffer]):
+        """Test that __len__ method of DataUser returns the length of the
+        buffer."""
+        assert len(data_user) == 0
+
+        data_user._buffer.data.append({"state": [1.0], "action": 1, "reward": 0.5})
+        assert len(data_user) == 1


### PR DESCRIPTION
# Pull Request

## 内容

#107 でTrainerの学習条件を設定するために、`DataBuffer`の抽象メソッドに `__len__`を追加しました。

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
