### PR TITLE
TrainersDictから学習可能なTrainerを取得する機能を削除

### DIFF
--- a/src/pamiq_core/trainer/container.py
+++ b/src/pamiq_core/trainer/container.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from pathlib import Path
-from typing import Any, override
+from typing import override
 
 from pamiq_core.data import DataUsersDict
 from pamiq_core.model import TrainingModelsDict
@@ -9,28 +9,7 @@ from pamiq_core.trainer import Trainer
 
 
 class TrainersDict(OrderedDict[str, Trainer], PersistentStateMixin):
-    def __init__(self, *args: Any, **kwds: Any) -> None:
-        """Initialize."""
-        super().__init__(*args, **kwds)
-        self._current_index = 0
-
-    def get_trainers_list(self) -> list[Trainer]:
-        """Retrieve trainers as a list."""
-        return list(self.values())
-
-    def get_trainable_trainer(self) -> Trainer | None:
-        """Retrieve trainable trainer in order one by one.
-
-        Returns:
-            If chosen trainer is trainable, returns trainer. Else None.
-        """
-        trainers = self.get_trainers_list()
-        for _ in range(len(trainers)):
-            trainer = trainers[self._current_index]
-            self._current_index = (self._current_index + 1) % len(self)
-            if trainer.is_trainable():
-                return trainer
-        return None
+    """A container class for trainers."""
 
     def attach_training_models_dict(
         self, training_models_dict: TrainingModelsDict

--- a/tests/pamiq_core/trainer/test_container.py
+++ b/tests/pamiq_core/trainer/test_container.py
@@ -49,25 +49,6 @@ class TestTrainersDict:
     def trainers_dict(self, trainers: dict[str, Trainer]) -> TrainersDict:
         return TrainersDict(trainers)
 
-    def test_get_trainers_list(
-        self, trainers_dict: TrainersDict, trainers: dict[str, Trainer]
-    ) -> None:
-        assert trainers_dict.get_trainers_list() == list(trainers.values())
-
-    def test_get_trainable_trainer(
-        self, trainers_dict: TrainersDict, trainers: Trainer
-    ) -> None:
-        assert trainers_dict.get_trainable_trainer() == trainers["trainable_1"]
-        assert trainers_dict.get_trainable_trainer() == trainers["trainable_2"]
-        # Check if it loops back to the first element.
-        assert trainers_dict.get_trainable_trainer() == trainers["trainable_1"]
-
-    def test_get_trainable_trainer_with_just_an_untrainable(
-        self, untrainable_trainer: Trainer
-    ) -> None:
-        trainers_dict = TrainersDict({"untrainable": untrainable_trainer})
-        assert trainers_dict.get_trainable_trainer() is None
-
     def test_attach_training_models_dict(
         self,
         mocker: MockerFixture,


### PR DESCRIPTION
# Pull Request

## 内容

#107 に関した変更です。Trainerは`run`メソッド内で`is_trainable`フラグをチェックし、`False`だった場合に`run`メソッドを早期リターンするように修正します。

その関係でTrainersDictに学習可能なTrainerを判別して取得する機能は要らなくなったため、その機能を削除しました。

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
