### PR TITLE
ThreadStatus 関連の class と utility function を実装 (ThreadStatus, ReadOnlyThreadStatus, ThreadStatusesHandler, and get_class_module_path)

### DIFF
--- a/src/pamiq_core/threads/__init__.py
+++ b/src/pamiq_core/threads/__init__.py
@@ -1,13 +1,21 @@
 from .thread_control import (
     ControllerCommandHandler,
     ReadOnlyController,
+    ReadOnlyThreadStatus,
     ThreadController,
+    ThreadStatus,
+    ThreadStatusesHandler,
 )
-from .thread_types import ThreadTypes
+from .thread_types import (
+    ThreadTypes,
+)
 
 __all__ = [
     "ThreadTypes",
     "ThreadController",
     "ReadOnlyController",
     "ControllerCommandHandler",
+    "ThreadStatus",
+    "ReadOnlyThreadStatus",
+    "ThreadStatusesHandler",
 ]

--- a/src/pamiq_core/threads/thread_control.py
+++ b/src/pamiq_core/threads/thread_control.py
@@ -200,13 +200,14 @@ class ReadOnlyThreadStatus:
 
 
 class ThreadStatusesHandler:
-    """A class to manage the statuses of multiple threads.
-
-    Args:
-        statuses: A dictionary of ThreadTypes and ReadOnlyThreadStatus objects.
-    """
+    """A class to manage the statuses of multiple threads."""
 
     def __init__(self, statuses: dict[ThreadTypes, ReadOnlyThreadStatus]) -> None:
+        """Initialize the ThreadStatusesHandler object.
+
+        Args:
+            statuses: A dictionary of ReadOnlyThreadStatus objects.
+        """
         self._statuses = statuses
         self._logger = logging.getLogger(get_class_module_path(self.__class__))
 

--- a/src/pamiq_core/threads/thread_control.py
+++ b/src/pamiq_core/threads/thread_control.py
@@ -3,7 +3,7 @@ import threading
 from concurrent.futures import Future, ThreadPoolExecutor
 
 from pamiq_core.threads.thread_types import ThreadTypes
-from pamiq_core.utils import get_class_module_path
+from pamiq_core.utils.reflection import get_class_module_path
 
 
 class ThreadController:

--- a/src/pamiq_core/utils/__init__.py
+++ b/src/pamiq_core/utils/__init__.py
@@ -1,3 +1,4 @@
 from . import schedulers
+from .reflection import get_class_module_path
 
-__all__ = ["schedulers"]
+__all__ = ["schedulers", "get_class_module_path"]

--- a/src/pamiq_core/utils/__init__.py
+++ b/src/pamiq_core/utils/__init__.py
@@ -1,5 +1,3 @@
-from . import schedulers, reflection
+from . import reflection, schedulers
 
-__all__ = ["schedulers", "reflection"]
-
-__all__ = ["schedulers", "get_class_module_path"]
+__all__ = ["reflection", "schedulers"]

--- a/src/pamiq_core/utils/__init__.py
+++ b/src/pamiq_core/utils/__init__.py
@@ -1,4 +1,5 @@
-from . import schedulers
-from .reflection import get_class_module_path
+from . import schedulers, reflection
+
+__all__ = ["schedulers", "reflection"]
 
 __all__ = ["schedulers", "get_class_module_path"]

--- a/src/pamiq_core/utils/reflection.py
+++ b/src/pamiq_core/utils/reflection.py
@@ -1,0 +1,3 @@
+def get_class_module_path(cls: type) -> str:
+    """Get the module path of a class."""
+    return f"{cls.__module__}.{cls.__name__}"

--- a/src/pamiq_core/utils/reflection.py
+++ b/src/pamiq_core/utils/reflection.py
@@ -1,3 +1,10 @@
 def get_class_module_path(cls: type) -> str:
-    """Get the module path of a class."""
+    """Get the module path of a class.
+
+    Args:
+        cls: The class to get the module path.
+
+    Returns:
+        str: The module path of the class.
+    """
     return f"{cls.__module__}.{cls.__name__}"

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -17,3 +17,28 @@ def skip_if_kernel_is_linuxkit():
         skip = True
 
     return pytest.mark.skipif(skip, reason="Linux kernel is linuxkit.")
+
+
+def check_log_message(
+    expected_log_message: str, log_level: str | None, caplog: pytest.LogCaptureFixture
+):
+    """Check if the expected log message is in the log messages.
+
+    Args:
+        expected_log_message: expected log message.
+        log_level: log level of the expected log message.
+        caplog: caplog fixture.
+
+    Raises:
+        AssertionError: if the expected log message is not in the log messages of specified log level.
+    """
+
+    if log_level:
+        error_level_log_messages = [
+            record.message for record in caplog.records if record.levelname == log_level
+        ]
+    else:
+        # if no log_level is specified, then check all log messages
+        error_level_log_messages = [record.message for record in caplog.records]
+
+    assert any(expected_log_message in message for message in error_level_log_messages)

--- a/tests/pamiq_core/threads/test_thread_control.py
+++ b/tests/pamiq_core/threads/test_thread_control.py
@@ -15,23 +15,25 @@ from pamiq_core.threads import (
 
 
 class TestThreadController:
+    """A test class for ThreadController."""
+
     @pytest.fixture()
-    def thread_controller(self):
+    def thread_controller(self) -> ThreadController:
         return ThreadController()
 
-    def test_initial_state(self, thread_controller: ThreadController):
+    def test_initial_state(self, thread_controller: ThreadController) -> None:
         assert thread_controller.is_resume() is True
         assert thread_controller.is_active() is True
 
     def test_resume_and_related_predicate_methods(
         self, thread_controller: ThreadController
-    ):
+    ) -> None:
         thread_controller.resume()
 
         assert thread_controller.is_resume() is True
         assert thread_controller.is_pause() is False
 
-    def test_resume_when_shutdown(self, thread_controller: ThreadController):
+    def test_resume_when_shutdown(self, thread_controller: ThreadController) -> None:
         thread_controller.shutdown()
 
         with pytest.raises(
@@ -41,13 +43,13 @@ class TestThreadController:
 
     def test_pause_and_related_predicate_methods(
         self, thread_controller: ThreadController
-    ):
+    ) -> None:
         thread_controller.pause()
 
         assert thread_controller.is_resume() is False
         assert thread_controller.is_pause() is True
 
-    def test_pause_when_shutdown(self, thread_controller: ThreadController):
+    def test_pause_when_shutdown(self, thread_controller: ThreadController) -> None:
         thread_controller.shutdown()
 
         with pytest.raises(
@@ -57,7 +59,7 @@ class TestThreadController:
 
     def test_shutdown_and_related_predicate_methods_when_resume(
         self, thread_controller: ThreadController
-    ):
+    ) -> None:
         thread_controller.shutdown()
 
         assert thread_controller.is_shutdown() is True
@@ -65,7 +67,7 @@ class TestThreadController:
 
     def test_shutdown_and_related_predicate_methods_when_pause(
         self, thread_controller: ThreadController
-    ):
+    ) -> None:
         thread_controller.pause()
         thread_controller.shutdown()
 
@@ -77,13 +79,15 @@ class TestThreadController:
 
     def test_activate_and_related_predicate_methods(
         self, thread_controller: ThreadController
-    ):
+    ) -> None:
         thread_controller.activate()
 
         assert thread_controller.is_shutdown() is False
         assert thread_controller.is_active() is True
 
-    def test_shutdown_when_already_shutdown(self, thread_controller: ThreadController):
+    def test_shutdown_when_already_shutdown(
+        self, thread_controller: ThreadController
+    ) -> None:
         thread_controller.shutdown()
 
         # Test that `resume()` in `shutdown()` does not raise an error
@@ -92,7 +96,7 @@ class TestThreadController:
 
     def test_wait_for_resume_when_already_resumed(
         self, thread_controller: ThreadController
-    ):
+    ) -> None:
         # immediately return True if already resumed
         thread_controller.resume()
         start = time.perf_counter()
@@ -101,7 +105,7 @@ class TestThreadController:
 
     def test_wait_for_resume_when_already_paused(
         self, thread_controller: ThreadController
-    ):
+    ) -> None:
         # wait timeout and return False if paused
         thread_controller.pause()
         start = time.perf_counter()
@@ -110,7 +114,7 @@ class TestThreadController:
 
     def test_wait_for_resume_when_resumed_after_waiting(
         self, thread_controller: ThreadController
-    ):
+    ) -> None:
         # immediately return True if resumed after waiting
         thread_controller.pause()
         threading.Timer(0.1, thread_controller.resume).start()
@@ -120,7 +124,9 @@ class TestThreadController:
 
 
 class TestReadOnlyController:
-    def test_exposed_methods(self):
+    """A test class for ReadOnlyController."""
+
+    def test_exposed_methods(self) -> None:
         thread_controller = ThreadController()
         read_only_controller = ReadOnlyController(thread_controller)
 
@@ -132,21 +138,23 @@ class TestReadOnlyController:
 
 
 class TestControllerCommandHandler:
+    """A test class for ControllerCommandHandler."""
+
     @pytest.fixture()
-    def thread_controller(self):
+    def thread_controller(self) -> ThreadController:
         return ThreadController()
 
     @pytest.fixture()
-    def read_only_controller(self, thread_controller):
+    def read_only_controller(self, thread_controller) -> ReadOnlyController:
         return ReadOnlyController(thread_controller)
 
     @pytest.fixture()
-    def handler(self, read_only_controller):
+    def handler(self, read_only_controller) -> ControllerCommandHandler:
         return ControllerCommandHandler(read_only_controller)
 
     def test_stop_if_pause_when_already_resumed(
         self, thread_controller: ThreadController, handler: ControllerCommandHandler
-    ):
+    ) -> None:
         # immediately return if already resumed
         thread_controller.resume()
         start = time.perf_counter()
@@ -155,7 +163,7 @@ class TestControllerCommandHandler:
 
     def test_stop_if_pause_pause_to_resume(
         self, thread_controller: ThreadController, handler: ControllerCommandHandler
-    ):
+    ) -> None:
         # immediately return if resumed after waiting
         thread_controller.pause()
         threading.Timer(0.1, thread_controller.resume).start()
@@ -165,7 +173,7 @@ class TestControllerCommandHandler:
 
     def test_stop_if_pause_when_already_shutdown(
         self, thread_controller: ThreadController, handler: ControllerCommandHandler
-    ):
+    ) -> None:
         # immediately return if already shutdown
         thread_controller.shutdown()
         start = time.perf_counter()
@@ -174,7 +182,7 @@ class TestControllerCommandHandler:
 
     def test_stop_if_pause_pause_to_shutdown(
         self, thread_controller: ThreadController, handler: ControllerCommandHandler
-    ):
+    ) -> None:
         # immediately return if shutdown after waiting
         thread_controller.pause()
         threading.Timer(0.1, thread_controller.shutdown).start()
@@ -184,7 +192,7 @@ class TestControllerCommandHandler:
 
     def test_manage_loop_when_already_resumed(
         self, thread_controller: ThreadController, handler: ControllerCommandHandler
-    ):
+    ) -> None:
         # immediately return True if already resumed
         thread_controller.resume()
         start = time.perf_counter()
@@ -193,7 +201,7 @@ class TestControllerCommandHandler:
 
     def test_manage_loop_pause_to_resume(
         self, thread_controller: ThreadController, handler: ControllerCommandHandler
-    ):
+    ) -> None:
         # immediately return True if resumed after waiting
         thread_controller.pause()
         threading.Timer(0.1, thread_controller.resume).start()
@@ -203,7 +211,7 @@ class TestControllerCommandHandler:
 
     def test_manage_loop_when_already_shutdown(
         self, thread_controller: ThreadController, handler: ControllerCommandHandler
-    ):
+    ) -> None:
         # immediately return False if already shutdown
         thread_controller.shutdown()
         start = time.perf_counter()
@@ -212,7 +220,7 @@ class TestControllerCommandHandler:
 
     def test_manage_loop_pause_to_shutdown(
         self, thread_controller: ThreadController, handler: ControllerCommandHandler
-    ):
+    ) -> None:
         # immediately return False if shutdown after waiting
         thread_controller.pause()
         threading.Timer(0.1, thread_controller.shutdown).start()
@@ -222,7 +230,7 @@ class TestControllerCommandHandler:
 
     def test_manage_loop_with_pause_resume_shutdown(
         self, thread_controller: ThreadController, handler: ControllerCommandHandler
-    ):
+    ) -> None:
         counter = 0
 
         def inifinity_count():
@@ -264,31 +272,39 @@ class TestControllerCommandHandler:
 
 
 class TestThreadStatus:
+    """A test class for ThreadStatus."""
+
     @pytest.fixture()
-    def thread_status(self):
+    def thread_status(self) -> ThreadStatus:
         """Fixture for thread status."""
         return ThreadStatus()
 
-    def test_initial_state(self, thread_status: ThreadStatus):
+    def test_initial_state(self, thread_status: ThreadStatus) -> None:
         """Test initial state of thread status."""
         assert thread_status.is_pause() is False
         assert thread_status.is_resume() is True
 
-    def test_pause_and_related_predicate_methods(self, thread_status: ThreadStatus):
+    def test_pause_and_related_predicate_methods(
+        self, thread_status: ThreadStatus
+    ) -> None:
         """Test pause and related predicate methods."""
         thread_status.pause()
 
         assert thread_status.is_pause() is True
         assert thread_status.is_resume() is False
 
-    def test_resume_and_related_predicate_methods(self, thread_status: ThreadStatus):
+    def test_resume_and_related_predicate_methods(
+        self, thread_status: ThreadStatus
+    ) -> None:
         """Test resume and related predicate methods."""
         thread_status.resume()
 
         assert thread_status.is_pause() is False
         assert thread_status.is_resume() is True
 
-    def test_wait_for_pause_when_already_paused(self, thread_status: ThreadStatus):
+    def test_wait_for_pause_when_already_paused(
+        self, thread_status: ThreadStatus
+    ) -> None:
         """Test wait_for_pause when the status is already paused."""
         # immediately return True if already paused
         thread_status.pause()
@@ -296,7 +312,9 @@ class TestThreadStatus:
         assert thread_status.wait_for_pause(0.1) is True
         assert time.perf_counter() - start < 1e-3
 
-    def test_wait_for_pause_when_already_resumed(self, thread_status: ThreadStatus):
+    def test_wait_for_pause_when_already_resumed(
+        self, thread_status: ThreadStatus
+    ) -> None:
         """Test wait_for_pause when the status is already resumed."""
         # wait timeout and return False if resumed
         thread_status.resume()
@@ -306,7 +324,7 @@ class TestThreadStatus:
 
     def test_wait_for_pause_when_paused_after_waiting(
         self, thread_status: ThreadStatus
-    ):
+    ) -> None:
         """Test wait_for_pause when the status is resumed at first, and paused
         after waiting."""
         # immediately return True if paused after waiting
@@ -318,7 +336,9 @@ class TestThreadStatus:
 
 
 class TestReadOnlyThreadStatus:
-    def test_exposed_methods(self):
+    """A test class for ReadOnlyThreadStatus."""
+
+    def test_exposed_methods(self) -> None:
         """Test of exposure of functions from ThreadStatus."""
         thread_status = ThreadStatus()
         read_only_thread_status = ReadOnlyThreadStatus(thread_status)
@@ -328,30 +348,36 @@ class TestReadOnlyThreadStatus:
 
 
 class TestThreadStatusesHandler:
+    """A test class for ThreadStatusesHandler."""
+
     @pytest.fixture()
-    def inference_thread_status(self):
+    def inference_thread_status(self) -> ThreadStatus:
         """Fixture for thread status, used for inference."""
         return ThreadStatus()
 
     @pytest.fixture()
-    def read_only_inference_thread_status(self, inference_thread_status):
+    def read_only_inference_thread_status(
+        self, inference_thread_status
+    ) -> ReadOnlyThreadStatus:
         """Fixture for read-only thread status, used for inference."""
         return ReadOnlyThreadStatus(inference_thread_status)
 
     @pytest.fixture()
-    def training_thread_status(self):
+    def training_thread_status(self) -> ThreadStatus:
         """Fixture for thread status, used for training."""
         return ThreadStatus()
 
     @pytest.fixture()
-    def read_only_training_thread_status(self, training_thread_status):
+    def read_only_training_thread_status(
+        self, training_thread_status
+    ) -> ReadOnlyThreadStatus:
         """Fixture for read-only thread status, used for training."""
         return ReadOnlyThreadStatus(training_thread_status)
 
     @pytest.fixture()
     def thread_status_handler(
         self, read_only_inference_thread_status, read_only_training_thread_status
-    ):
+    ) -> ThreadStatusesHandler:
         """Fixture for thread status handler."""
         return ThreadStatusesHandler(
             {
@@ -360,7 +386,7 @@ class TestThreadStatusesHandler:
             }
         )
 
-    def test_wait_for_all_threads_pause_when_empty_status(self):
+    def test_wait_for_all_threads_pause_when_empty_status(self) -> None:
         """Test wait_for_all_threads_pause when statuses is empty."""
         # immediately return True if statuses is empty
         thread_status_handler = ThreadStatusesHandler(statuses={})
@@ -370,7 +396,7 @@ class TestThreadStatusesHandler:
 
     def test_wait_for_all_threads_pause_all_when_all_threads_paused(
         self, inference_thread_status, training_thread_status, thread_status_handler
-    ):
+    ) -> None:
         """Test wait_for_all_threads_pause when all threads are paused."""
         # immediately return True if all threads are paused
         inference_thread_status.pause()
@@ -378,7 +404,7 @@ class TestThreadStatusesHandler:
 
         start = time.perf_counter()
         assert thread_status_handler.wait_for_all_threads_pause(0.1) is True
-        assert time.perf_counter() - start < 2e-3  # test not passed if 1e-3
+        assert time.perf_counter() - start < 1e-2  # test not passed if 1e-3
 
     @pytest.mark.parametrize(
         "is_inference_resumed, is_training_resumed",
@@ -396,7 +422,7 @@ class TestThreadStatusesHandler:
         inference_thread_status,
         training_thread_status,
         thread_status_handler,
-    ):
+    ) -> None:
         """Test wait_for_all_threads_pause when some threads are resumed."""
         # wait timeout and return False if some threads are resumed
         inference_thread_status.pause()
@@ -444,7 +470,7 @@ class TestThreadStatusesHandler:
         inference_thread_status,
         training_thread_status,
         thread_status_handler,
-    ):
+    ) -> None:
         """Test wait_for_all_threads_pause when all threads are paused after
         waiting."""
         # immediately return True if all threads are paused after waiting

--- a/tests/pamiq_core/threads/test_thread_control.py
+++ b/tests/pamiq_core/threads/test_thread_control.py
@@ -439,18 +439,6 @@ class TestThreadStatusesHandler:
         assert 0.1 <= time.perf_counter() - start < 0.2
 
         # check log messages
-        def _check_log_message(thread_type: ThreadTypes):
-            expected_log_message = f"Timeout waiting for '{thread_type.thread_name}' thread to pause after 0.1 seconds."
-
-            error_level_log_messages = [
-                record.message
-                for record in caplog.records
-                if record.levelname == "ERROR"
-            ]
-            assert any(
-                expected_log_message in message for message in error_level_log_messages
-            )
-
         if is_inference_resumed:
             check_log_message(
                 expected_log_message="Timeout waiting for 'inference' thread to pause after 0.1 seconds.",

--- a/tests/pamiq_core/threads/test_thread_control.py
+++ b/tests/pamiq_core/threads/test_thread_control.py
@@ -12,6 +12,7 @@ from pamiq_core.threads import (
     ThreadStatusesHandler,
     ThreadTypes,
 )
+from tests.helpers import check_log_message
 
 
 class TestThreadController:
@@ -451,9 +452,17 @@ class TestThreadStatusesHandler:
             )
 
         if is_inference_resumed:
-            _check_log_message(ThreadTypes.INFERENCE)
+            check_log_message(
+                expected_log_message="Timeout waiting for 'inference' thread to pause after 0.1 seconds.",
+                log_level="ERROR",
+                caplog=caplog,
+            )
         if is_training_resumed:
-            _check_log_message(ThreadTypes.TRAINING)
+            check_log_message(
+                expected_log_message="Timeout waiting for 'training' thread to pause after 0.1 seconds.",
+                log_level="ERROR",
+                caplog=caplog,
+            )
 
     @pytest.mark.parametrize(
         "is_inference_resumed, is_training_resumed",

--- a/tests/pamiq_core/utils/test_reflection.py
+++ b/tests/pamiq_core/utils/test_reflection.py
@@ -1,9 +1,14 @@
 from pamiq_core.utils import get_class_module_path
 
 
-def test_get_class_module_path():
-    class TestClass:
-        pass
+class TestClass:
+    """A class used only for testing purposes."""
+
+    pass
+
+
+def test_get_class_module_path() -> None:
+    """Test the get_class_module_path function."""
 
     assert (
         get_class_module_path(TestClass)

--- a/tests/pamiq_core/utils/test_reflection.py
+++ b/tests/pamiq_core/utils/test_reflection.py
@@ -1,0 +1,14 @@
+from pamiq_core.utils import get_class_module_path
+
+
+def test_get_class_module_path():
+    class TestClass:
+        pass
+
+    assert (
+        get_class_module_path(TestClass)
+        == "tests.pamiq_core.utils.test_reflection.TestClass"
+    )
+    assert (
+        get_class_module_path(int) == "builtins.int"
+    )  # "builtins" is the module name for built-in objects

--- a/tests/pamiq_core/utils/test_reflection.py
+++ b/tests/pamiq_core/utils/test_reflection.py
@@ -1,4 +1,4 @@
-from pamiq_core.utils import get_class_module_path
+from pamiq_core.utils.reflection import get_class_module_path
 
 
 class TestClass:


### PR DESCRIPTION
# Pull Request

## 内容

#36 の実装
- ThreadStatus 関連の class を実装 (`ThreadStatus`, `ReadOnlyThreadStatus`, `ThreadStatusesHandler`)
- class の module path を手に入れる util func の実装（ログ送出に利用） (`get_class_module_path`)

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

以下、3つの質問があります！

- 質問：`ThreadStatusesHandler.wait_for_all_threads_pause()` においては、 status が空の場合は即座に True を返すべしという実装にしました。これでよいでしょうか？
    - 理由：`ThreadPoolExecutor` の `max_workers` は 0 より大きくないと ValueError を吐くため、それを回避
    - ですが、そもそも status が空というのは想定していない気もします。その場合は、そもそも `ThreadStatusesHandler` のコンストラクタで ValueError とかを吐くようにしたほうがいいかもしれません
    - ユースケース的に、どちらがいいか（または別案があるか）、教えていただけると助かります！
- 質問：`ThreadStatusesHandler.wait_for_all_threads_pause()` のテストで、実際に error レベルのログを吐いていますが、これでよいでしょうか？
    - こうすると、`make run` 実行時にログに Error が流れて嫌だなと思っています
    - mocker を使ったテストにした方がいいかと思っているのですが、いかがでしょうか？　（私が決めていいなら、mocker に切り替えようと思っています）
- 質問：parametrize を使いました。これで可読性的には良いでしょうか？
    - `test_wait_for_all_threads_pause_when_some_threads_resumed()` と `test_wait_for_all_threads_pause_all_when_paused_after_waiting` には parametrize を使いました。
    - 私としては、良くなっていると思います！
    - ですが、やや大仰なので、げそんさんの目でも見ていただけると助かります





