### PR TITLE
EnvironmentWrapper, ActuatorWrapper, SensorWrapperが関数をそのままラッパーとして受け取れるようリファクタリング

### DIFF
--- a/tests/pamiq_core/interaction/test_wrappers.py
+++ b/tests/pamiq_core/interaction/test_wrappers.py
@@ -155,6 +155,21 @@ class TestEnvironmentWrapper:
         obs_load_spy.assert_called_once_with(load_path / "obs_wrapper")
         act_load_spy.assert_called_once_with(load_path / "act_wrapper")
 
+    def test_with_function_wrappers(self, mock_env):
+        """Test creating EnvironmentWrapper with direct function wrappers."""
+        # Create wrapper with functions directly
+        env_wrapper = EnvironmentWrapper(
+            mock_env, lambda x: f"func_wrapped_{x}", lambda x: f"func_unwrapped_{x}"
+        )
+
+        # Test observation wrapping
+        result = env_wrapper.observe()
+        assert result == "func_wrapped_raw_observation"
+
+        # Test action wrapping
+        env_wrapper.affect("direct_action")
+        mock_env.affect.assert_called_with("func_unwrapped_direct_action")
+
 
 class TestSensorWrapper:
     """Test suite for the SensorWrapper class."""
@@ -229,6 +244,15 @@ class TestSensorWrapper:
 
         mock_sensor.load_state.assert_called_once_with(load_path / "sensor")
         wrapper_load_spy.assert_called_once_with(load_path / "wrapper")
+
+    def test_with_function_wrapper(self, mock_sensor):
+        """Test creating SensorWrapper with a direct function wrapper."""
+        # Create wrapper with function directly
+        sensor_wrapper = SensorWrapper(mock_sensor, lambda x: f"func_processed_{x}")
+
+        # Test reading
+        result = sensor_wrapper.read()
+        assert result == "func_processed_raw_sensor_data"
 
 
 class TestActuatorWrapper:
@@ -306,3 +330,14 @@ class TestActuatorWrapper:
 
         mock_actuator.load_state.assert_called_once_with(load_path / "actuator")
         wrapper_load_spy.assert_called_once_with(load_path / "wrapper")
+
+    def test_with_function_wrapper(self, mock_actuator):
+        """Test creating ActuatorWrapper with a direct function wrapper."""
+        # Create wrapper with function directly
+        actuator_wrapper = ActuatorWrapper(
+            mock_actuator, lambda x: f"func_transformed_{x}"
+        )
+
+        # Test operation
+        actuator_wrapper.operate("direct_action")
+        mock_actuator.operate.assert_called_once_with("func_transformed_direct_action")


### PR DESCRIPTION
# Pull Request

## 内容

今後ラッパー関数を、`Wrapper`クラスを介さずそのまま使用する需要を見据えて、EnvironmentWrapper, ActuatorWrapper, SensorWrapperが関数をそのままラッパーとして受け取れるようリファクタリングしました。

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
