### PR TITLE
add callbacks to handle pause/resume event for ControllerCommandHandler

### DIFF
--- a/src/pamiq_core/threads/thread_control.py
+++ b/src/pamiq_core/threads/thread_control.py
@@ -10,6 +10,18 @@ type OnPausedCallback = Callable[[], None]
 type OnResumedCallback = Callable[[], None]
 
 
+class ThreadEventMixin:
+    """A mixin class to provide event handling methods for a thread."""
+
+    def on_paused(self) -> None:
+        """The method to be called when the thread is paused."""
+        pass
+
+    def on_resumed(self) -> None:
+        """The method to be called when the thread is resumed."""
+        pass
+
+
 class ThreadController:
     """The controller class for sending commands from the control thread to
     other threads.
@@ -136,14 +148,14 @@ class ControllerCommandHandler:
             # In this implementation, `self._on_pause()` is invoked almost immediately when a pause occurs.
             # Because the `ControllerCommandHandler` primarily runs `manage_loop()`,
             # the `stop_if_pause()` method is frequently executed.
-            self._on_paused()
+            self.on_paused()
             paused = True
 
         while not self._controller.wait_for_resume(1.0):
             pass
 
         if paused:
-            self._on_resumed()
+            self.on_resumed()
 
     def manage_loop(self) -> bool:
         """Manages the infinite loop: blocking during thread is paused, and returning thread's activity flag.
@@ -264,15 +276,3 @@ class ThreadStatusesHandler:
                 )
             success &= result
         return success
-
-
-class ThreadEventMixin:
-    """A mixin class to provide event handling methods for a thread."""
-
-    def on_paused(self) -> None:
-        """The method to be called when the thread is paused."""
-        pass
-
-    def on_resumed(self) -> None:
-        """The method to be called when the thread is resumed."""
-        pass

--- a/src/pamiq_core/threads/thread_control.py
+++ b/src/pamiq_core/threads/thread_control.py
@@ -269,10 +269,10 @@ class ThreadStatusesHandler:
 class ThreadEventMixin:
     """A mixin class to provide event handling methods for a thread."""
 
-    def _on_paused(self) -> None:
+    def on_paused(self) -> None:
         """The method to be called when the thread is paused."""
         pass
 
-    def _on_resumed(self) -> None:
+    def on_resumed(self) -> None:
         """The method to be called when the thread is resumed."""
         pass

--- a/src/pamiq_core/threads/thread_control.py
+++ b/src/pamiq_core/threads/thread_control.py
@@ -119,8 +119,8 @@ class ControllerCommandHandler:
             on_resumed_callback: The callback function to be called when the thread is resumed.
         """
         self._controller = controller
-        self._on_paused = on_paused_callback
-        self._on_resumed = on_resumed_callback
+        self.on_paused = on_paused_callback
+        self.on_resumed = on_resumed_callback
 
     def stop_if_pause(self) -> None:
         """Wait until the thread is resumed, or return immediately if the

--- a/src/pamiq_core/threads/thread_control.py
+++ b/src/pamiq_core/threads/thread_control.py
@@ -1,9 +1,13 @@
 import logging
 import threading
+from collections.abc import Callable
 from concurrent.futures import Future, ThreadPoolExecutor
 
 from pamiq_core.threads.thread_types import ThreadTypes
 from pamiq_core.utils.reflection import get_class_module_path
+
+type OnPausedCallback = Callable[[], None]
+type OnResumedCallback = Callable[[], None]
 
 
 class ThreadController:
@@ -99,25 +103,47 @@ class ReadOnlyController:
 
 class ControllerCommandHandler:
     """A class, handles commands for thread management, facilitating
-    communication and control between the control thread and other threads.
+    communication and control between the control thread and other threads."""
 
-    Args:
-        controller: The ReadOnlyController object to be read.
-    """
+    def __init__(
+        self,
+        controller: ReadOnlyController,
+        on_paused_callback: OnPausedCallback = lambda: None,
+        on_resumed_callback: OnResumedCallback = lambda: None,
+    ) -> None:
+        """Initialize the ControllerCommandHandler object.
 
-    def __init__(self, controller: ReadOnlyController) -> None:
+        Args:
+            controller: The ReadOnlyController object to be read.
+            on_paused_callback: The callback function to be called when the thread is paused.
+            on_resumed_callback: The callback function to be called when the thread is resumed.
+        """
         self._controller = controller
+        self._on_paused = on_paused_callback
+        self._on_resumed = on_resumed_callback
 
     def stop_if_pause(self) -> None:
-        """This function is used to stop the execution of the current thread if
-        the thread is paused.
+        """Wait until the thread is resumed, or return immediately if the
+        thread is resumed. on_paused_callback and on_resumed_callback will be
+        called when the thread is paused and resumed, respectively.
 
         Behavior of this function:
         * If the thread is resume: the function will return immediately.
         * If the thread is paused: the function will block until the thread is resumed or shutdown.
         """
+        paused = False
+        if self._controller.is_pause():
+            # In this implementation, `self._on_pause()` is invoked almost immediately when a pause occurs.
+            # Because the `ControllerCommandHandler` primarily runs `manage_loop()`,
+            # the `stop_if_pause()` method is frequently executed.
+            self._on_paused()
+            paused = True
+
         while not self._controller.wait_for_resume(1.0):
             pass
+
+        if paused:
+            self._on_resumed()
 
     def manage_loop(self) -> bool:
         """Manages the infinite loop: blocking during thread is paused, and returning thread's activity flag.
@@ -238,3 +264,15 @@ class ThreadStatusesHandler:
                 )
             success &= result
         return success
+
+
+class ThreadEventMixin:
+    """A mixin class to provide event handling methods for a thread."""
+
+    def _on_paused(self) -> None:
+        """The method to be called when the thread is paused."""
+        pass
+
+    def _on_resumed(self) -> None:
+        """The method to be called when the thread is resumed."""
+        pass

--- a/tests/pamiq_core/threads/test_thread_control.py
+++ b/tests/pamiq_core/threads/test_thread_control.py
@@ -180,8 +180,8 @@ class TestControllerCommandHandler:
         mocker,
     ) -> None:
         # prepare mock objects
-        on_paused_callback_mock = mocker.spy(handler, "_on_paused")
-        on_resumed_callback_mock = mocker.spy(handler, "_on_resumed")
+        on_paused_callback_mock = mocker.spy(handler, "on_paused")
+        on_resumed_callback_mock = mocker.spy(handler, "on_resumed")
 
         # immediately return if resumed after waiting
         thread_controller.pause()

--- a/tests/pamiq_core/threads/test_thread_control.py
+++ b/tests/pamiq_core/threads/test_thread_control.py
@@ -180,8 +180,8 @@ class TestControllerCommandHandler:
         mocker,
     ) -> None:
         # prepare mock objects
-        on_paused_callback_mock = mocker.patch.object(handler, "_on_paused")
-        on_resumed_callback_mock = mocker.patch.object(handler, "_on_resumed")
+        on_paused_callback_mock = mocker.spy(handler, "_on_paused")
+        on_resumed_callback_mock = mocker.spy(handler, "_on_resumed")
 
         # immediately return if resumed after waiting
         thread_controller.pause()

--- a/tests/pamiq_core/threads/test_thread_control.py
+++ b/tests/pamiq_core/threads/test_thread_control.py
@@ -160,8 +160,8 @@ class TestControllerCommandHandler:
         mocker,
     ) -> None:
         # prepare mock objects
-        on_paused_callback_mock = mocker.patch.object(handler, "_on_paused")
-        on_resumed_callback_mock = mocker.patch.object(handler, "_on_resumed")
+        on_paused_callback_mock = mocker.spy(handler, "on_paused")
+        on_resumed_callback_mock = mocker.spy(handler, "on_resumed")
 
         # immediately return if already resumed
         thread_controller.resume()

--- a/tests/pamiq_core/threads/test_thread_control.py
+++ b/tests/pamiq_core/threads/test_thread_control.py
@@ -191,8 +191,8 @@ class TestControllerCommandHandler:
         assert 0.1 <= time.perf_counter() - start < 0.2
 
         # callbacks are called
-        on_paused_callback_mock.assert_called_once()
-        on_resumed_callback_mock.assert_called_once()
+        on_paused_callback_mock.assert_called_once_with()
+        on_resumed_callback_mock.assert_called_once_with()
 
     def test_stop_if_pause_when_already_shutdown(
         self, thread_controller: ThreadController, handler: ControllerCommandHandler


### PR DESCRIPTION
# Pull Request

## 内容

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

#38 
- `ControllerCommandHandler` の `stop_if_pause()` function 内に、on_pause と on_resume の callback を行う仕組みを追加
- on_pause と on_resume のインターフェイスを注入する Mixin の作成

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

以下2つを見ていただけると助かります！

- `self.on_xxxx` は、private のほうが良いかと思い、`self._on_xxxx` に修正しました
    - （そのため、mixin の方でも関数名を変更しています）
- `stop_if_pause()` のテストでは、時間差についてのテストは実行していません
    - たとえば、`self._on_resumed()` が resume の直後の実行であるという時間差の確認はしていません（pause も同様）
    - 理由薄弱ですが、そこまでは不要かなと思ったためです。でも、理由は薄弱で、自信はありません。やったほうが良ければ実装するので教えていただけると嬉しいです！