### PR TITLE
ThreadControllerとThreadStatusに`read_only` propertyを追加

### DIFF
--- a/src/pamiq_core/threads/thread_control.py
+++ b/src/pamiq_core/threads/thread_control.py
@@ -36,7 +36,7 @@ class ThreadController:
         """Get a read-only view of this controller.
 
         Returns:
-            ReadOnlyController: A read-only interface to this controller.
+            A read-only interface to this controller.
         """
         return ReadOnlyController(self)
 
@@ -199,7 +199,7 @@ class ThreadStatus:
         """Get a read-only view of this thread status.
 
         Returns:
-            ReadOnlyThreadStatus: A read-only interface to this thread status.
+            A read-only interface to this thread status.
         """
 
         return ReadOnlyThreadStatus(self)

--- a/src/pamiq_core/threads/thread_control.py
+++ b/src/pamiq_core/threads/thread_control.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import threading
 from collections.abc import Callable
@@ -28,6 +30,15 @@ class ThreadController:
 
     NOTE: **Only one thread can control this object.**
     """
+
+    @property
+    def read_only(self) -> ReadOnlyController:
+        """Get a read-only view of this controller.
+
+        Returns:
+            ReadOnlyController: A read-only interface to this controller.
+        """
+        return ReadOnlyController(self)
 
     def __init__(self) -> None:
         self._shutdown_event = threading.Event()
@@ -182,6 +193,16 @@ class ThreadStatus:
     The readonly interface is provided by the ReadOnlyThreadStatus class
     and mainly used for monitoring the status of a thread.
     """
+
+    @property
+    def read_only(self) -> ReadOnlyThreadStatus:
+        """Get a read-only view of this thread status.
+
+        Returns:
+            ReadOnlyThreadStatus: A read-only interface to this thread status.
+        """
+
+        return ReadOnlyThreadStatus(self)
 
     def __init__(self) -> None:
         self._paused_event = threading.Event()

--- a/tests/pamiq_core/threads/test_thread_control.py
+++ b/tests/pamiq_core/threads/test_thread_control.py
@@ -22,6 +22,11 @@ class TestThreadController:
     def thread_controller(self) -> ThreadController:
         return ThreadController()
 
+    def test_read_only_property(self, thread_controller: ThreadController) -> None:
+        """Test that the read_only property returns a valid
+        ReadOnlyController."""
+        assert isinstance(thread_controller.read_only, ReadOnlyController)
+
     def test_initial_state(self, thread_controller: ThreadController) -> None:
         assert thread_controller.is_resume() is True
         assert thread_controller.is_active() is True
@@ -303,6 +308,11 @@ class TestThreadStatus:
     def thread_status(self) -> ThreadStatus:
         """Fixture for thread status."""
         return ThreadStatus()
+
+    def test_read_only_property(self, thread_status: ThreadStatus) -> None:
+        """Test that the read_only property returns a valid
+        ReadOnlyThreadStatus."""
+        assert isinstance(thread_status.read_only, ReadOnlyThreadStatus)
 
     def test_initial_state(self, thread_status: ThreadStatus) -> None:
         """Test initial state of thread status."""


### PR DESCRIPTION
# Pull Request

## 内容

今後制御処理を実装するにあたって、ThreadControllerとThreadStatusのReadOnlyクラスがpropertyから取得できた方が都合が良いため、実装しました。

ReadOnlyクラスと元のクラスは本質的には同一のオブジェクトなので、プロパティとして持っている方が自然というのもあります（ただしReadOnlyクラスからWritableなクラスを参照できてはいけないが...）

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
