### PR TITLE
ThreadStatusesHandlerをThreadStatusesMonitorに名称変更

### DIFF
--- a/src/pamiq_core/console/system_status.py
+++ b/src/pamiq_core/console/system_status.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from enum import Enum, auto
 
-from pamiq_core.threads import ReadOnlyController, ThreadStatusesHandler
+from pamiq_core.threads import ReadOnlyController, ThreadStatusesMonitor
 
 
 class SystemStatus(Enum):
@@ -45,16 +45,16 @@ class SystemStatusProvider:
     def __init__(
         self,
         controller: ReadOnlyController,
-        thread_statuses_handler: ThreadStatusesHandler,
+        thread_statuses_monitor: ThreadStatusesMonitor,
     ) -> None:
         """Initialize the SystemStatusProvider.
 
         Args:
             controller: A read-only interface to the thread controller
-            thread_statuses_handler: Handler for managing and querying thread statuses
+            thread_statuses_monitor: Monitor for observing and querying thread statuses
         """
         self._controller = controller
-        self._thread_statuses_handler = thread_statuses_handler
+        self._thread_statuses_monitor = thread_statuses_monitor
 
     def get_current_status(self) -> SystemStatus:
         """Determine the current status of the system.
@@ -73,12 +73,12 @@ class SystemStatusProvider:
             return SystemStatus.SHUTTING_DOWN
 
         if self._controller.is_pause():
-            if self._thread_statuses_handler.check_all_threads_paused():
+            if self._thread_statuses_monitor.check_all_threads_paused():
                 return SystemStatus.PAUSED
             else:
                 return SystemStatus.PAUSING
         elif self._controller.is_resume():
-            if self._thread_statuses_handler.check_any_threads_paused():
+            if self._thread_statuses_monitor.check_any_threads_paused():
                 return SystemStatus.RESUMING
 
         return SystemStatus.ACTIVE

--- a/src/pamiq_core/threads/__init__.py
+++ b/src/pamiq_core/threads/__init__.py
@@ -5,7 +5,7 @@ from .thread_control import (
     ThreadController,
     ThreadEventMixin,
     ThreadStatus,
-    ThreadStatusesHandler,
+    ThreadStatusesMonitor,
 )
 from .thread_types import (
     ThreadTypes,
@@ -18,6 +18,6 @@ __all__ = [
     "ControllerCommandHandler",
     "ThreadStatus",
     "ReadOnlyThreadStatus",
-    "ThreadStatusesHandler",
+    "ThreadStatusesMonitor",
     "ThreadEventMixin",
 ]

--- a/src/pamiq_core/threads/thread_control.py
+++ b/src/pamiq_core/threads/thread_control.py
@@ -276,11 +276,11 @@ class ReadOnlyThreadStatus:
         self.is_exception_raised = status.is_exception_raised
 
 
-class ThreadStatusesHandler:
-    """A class to manage the statuses of multiple threads."""
+class ThreadStatusesMonitor:
+    """A class to monitor the statuses of multiple threads."""
 
     def __init__(self, statuses: dict[ThreadTypes, ReadOnlyThreadStatus]) -> None:
-        """Initialize the ThreadStatusesHandler object.
+        """Initialize the ThreadStatusesMonitor object.
 
         Args:
             statuses: A dictionary of ReadOnlyThreadStatus objects.

--- a/tests/pamiq_core/console/test_system_status.py
+++ b/tests/pamiq_core/console/test_system_status.py
@@ -7,7 +7,7 @@ from pamiq_core.console.system_status import (
 from pamiq_core.threads import (
     ThreadController,
     ThreadStatus,
-    ThreadStatusesHandler,
+    ThreadStatusesMonitor,
     ThreadTypes,
 )
 
@@ -31,14 +31,14 @@ class TestSystemStatusProvider:
         return ThreadStatus()
 
     @pytest.fixture()
-    def thread_statuses_handler(
+    def thread_statuses_monitor(
         self,
         inference_thread_status: ThreadStatus,
         training_thread_status: ThreadStatus,
-    ) -> ThreadStatusesHandler:
-        """Fixture for a ThreadStatusesHandler instance with real thread
+    ) -> ThreadStatusesMonitor:
+        """Fixture for a ThreadStatusesMonitor instance with real thread
         statuses."""
-        return ThreadStatusesHandler(
+        return ThreadStatusesMonitor(
             {
                 ThreadTypes.INFERENCE: inference_thread_status.read_only,
                 ThreadTypes.TRAINING: training_thread_status.read_only,
@@ -49,11 +49,11 @@ class TestSystemStatusProvider:
     def status_provider(
         self,
         thread_controller: ThreadController,
-        thread_statuses_handler: ThreadStatusesHandler,
+        thread_statuses_monitor: ThreadStatusesMonitor,
     ) -> SystemStatusProvider:
         """Fixture for a SystemStatusProvider instance with real objects."""
         return SystemStatusProvider(
-            thread_controller.read_only, thread_statuses_handler
+            thread_controller.read_only, thread_statuses_monitor
         )
 
     def test_status_shutting_down(

--- a/tests/pamiq_core/threads/test_thread_control.py
+++ b/tests/pamiq_core/threads/test_thread_control.py
@@ -423,7 +423,7 @@ class TestThreadStatusesMonitor:
         return ReadOnlyThreadStatus(training_thread_status)
 
     @pytest.fixture()
-    def thread_status_handler(
+    def thread_statuses_monitor(
         self, read_only_inference_thread_status, read_only_training_thread_status
     ) -> ThreadStatusesMonitor:
         """Fixture for thread status monitor."""
@@ -437,13 +437,13 @@ class TestThreadStatusesMonitor:
     def test_wait_for_all_threads_pause_when_empty_status(self) -> None:
         """Test wait_for_all_threads_pause when statuses is empty."""
         # immediately return True if statuses is empty
-        thread_status_handler = ThreadStatusesMonitor(statuses={})
+        thread_statuses_monitor = ThreadStatusesMonitor(statuses={})
         start = time.perf_counter()
-        assert thread_status_handler.wait_for_all_threads_pause(0.1) is True
+        assert thread_statuses_monitor.wait_for_all_threads_pause(0.1) is True
         assert time.perf_counter() - start < 1e-3
 
     def test_wait_for_all_threads_pause_all_when_all_threads_paused(
-        self, inference_thread_status, training_thread_status, thread_status_handler
+        self, inference_thread_status, training_thread_status, thread_statuses_monitor
     ) -> None:
         """Test wait_for_all_threads_pause when all threads are paused."""
         # immediately return True if all threads are paused
@@ -451,7 +451,7 @@ class TestThreadStatusesMonitor:
         training_thread_status.pause()
 
         start = time.perf_counter()
-        assert thread_status_handler.wait_for_all_threads_pause(0.1) is True
+        assert thread_statuses_monitor.wait_for_all_threads_pause(0.1) is True
         assert time.perf_counter() - start < 1e-2  # test not passed if 1e-3
 
     @pytest.mark.parametrize(
@@ -469,7 +469,7 @@ class TestThreadStatusesMonitor:
         is_training_resumed,
         inference_thread_status,
         training_thread_status,
-        thread_status_handler,
+        thread_statuses_monitor,
     ) -> None:
         """Test wait_for_all_threads_pause when some threads are resumed."""
         # wait timeout and return False if some threads are resumed
@@ -482,7 +482,7 @@ class TestThreadStatusesMonitor:
             training_thread_status.resume()
 
         start = time.perf_counter()
-        assert thread_status_handler.wait_for_all_threads_pause(0.1) is False
+        assert thread_statuses_monitor.wait_for_all_threads_pause(0.1) is False
         assert 0.1 <= time.perf_counter() - start < 0.2
 
         # check log messages
@@ -513,7 +513,7 @@ class TestThreadStatusesMonitor:
         is_training_resumed,
         inference_thread_status,
         training_thread_status,
-        thread_status_handler,
+        thread_statuses_monitor,
     ) -> None:
         """Test wait_for_all_threads_pause when all threads are paused after
         waiting."""
@@ -529,7 +529,7 @@ class TestThreadStatusesMonitor:
             threading.Timer(0.1, training_thread_status.pause).start()
 
         start = time.perf_counter()
-        assert thread_status_handler.wait_for_all_threads_pause(0.5) is True
+        assert thread_statuses_monitor.wait_for_all_threads_pause(0.5) is True
         assert 0.1 <= time.perf_counter() - start < 0.2
 
     @pytest.mark.parametrize(
@@ -548,7 +548,7 @@ class TestThreadStatusesMonitor:
         is_training_exception_raised,
         inference_thread_status,
         training_thread_status,
-        thread_status_handler,
+        thread_statuses_monitor,
     ) -> None:
         """Test check_exception_raised: return value and log messages."""
         if is_inference_exception_raised:
@@ -556,7 +556,7 @@ class TestThreadStatusesMonitor:
         if is_training_exception_raised:
             training_thread_status.exception_raised()
 
-        assert thread_status_handler.check_exception_raised() is any(
+        assert thread_statuses_monitor.check_exception_raised() is any(
             [is_inference_exception_raised, is_training_exception_raised]
         )
 
@@ -576,8 +576,8 @@ class TestThreadStatusesMonitor:
 
     def test_check_all_threads_paused_empty_statuses(self) -> None:
         """Test check_all_threads_paused when statuses is empty."""
-        thread_status_handler = ThreadStatusesMonitor(statuses={})
-        assert thread_status_handler.check_all_threads_paused() is True
+        thread_statuses_monitor = ThreadStatusesMonitor(statuses={})
+        assert thread_statuses_monitor.check_all_threads_paused() is True
 
     @pytest.mark.parametrize(
         "is_inference_paused, is_training_paused, expected_result",
@@ -595,7 +595,7 @@ class TestThreadStatusesMonitor:
         expected_result,
         inference_thread_status,
         training_thread_status,
-        thread_status_handler,
+        thread_statuses_monitor,
     ) -> None:
         """Test check_all_threads_paused with different thread pause states."""
         # Set initial state to resumed
@@ -608,12 +608,12 @@ class TestThreadStatusesMonitor:
         if is_training_paused:
             training_thread_status.pause()
 
-        assert thread_status_handler.check_all_threads_paused() is expected_result
+        assert thread_statuses_monitor.check_all_threads_paused() is expected_result
 
     def test_check_any_threads_paused_empty_statuses(self) -> None:
         """Test check_any_threads_paused when statuses is empty."""
-        thread_status_handler = ThreadStatusesMonitor(statuses={})
-        assert thread_status_handler.check_any_threads_paused() is False
+        thread_statuses_monitor = ThreadStatusesMonitor(statuses={})
+        assert thread_statuses_monitor.check_any_threads_paused() is False
 
     @pytest.mark.parametrize(
         "is_inference_paused, is_training_paused, expected_result",
@@ -631,7 +631,7 @@ class TestThreadStatusesMonitor:
         expected_result,
         inference_thread_status,
         training_thread_status,
-        thread_status_handler,
+        thread_statuses_monitor,
     ) -> None:
         """Test check_any_threads_paused with different thread pause states."""
         # Set initial state to resumed
@@ -644,4 +644,4 @@ class TestThreadStatusesMonitor:
         if is_training_paused:
             training_thread_status.pause()
 
-        assert thread_status_handler.check_any_threads_paused() is expected_result
+        assert thread_statuses_monitor.check_any_threads_paused() is expected_result

--- a/tests/pamiq_core/threads/test_thread_control.py
+++ b/tests/pamiq_core/threads/test_thread_control.py
@@ -9,7 +9,7 @@ from pamiq_core.threads import (
     ReadOnlyThreadStatus,
     ThreadController,
     ThreadStatus,
-    ThreadStatusesHandler,
+    ThreadStatusesMonitor,
     ThreadTypes,
 )
 from tests.helpers import check_log_message
@@ -395,8 +395,8 @@ class TestReadOnlyThreadStatus:
         assert read_only_thread_status.wait_for_pause == thread_status.wait_for_pause
 
 
-class TestThreadStatusesHandler:
-    """A test class for ThreadStatusesHandler."""
+class TestThreadStatusesMonitor:
+    """A test class for ThreadStatusesMonitor."""
 
     @pytest.fixture()
     def inference_thread_status(self) -> ThreadStatus:
@@ -425,9 +425,9 @@ class TestThreadStatusesHandler:
     @pytest.fixture()
     def thread_status_handler(
         self, read_only_inference_thread_status, read_only_training_thread_status
-    ) -> ThreadStatusesHandler:
-        """Fixture for thread status handler."""
-        return ThreadStatusesHandler(
+    ) -> ThreadStatusesMonitor:
+        """Fixture for thread status monitor."""
+        return ThreadStatusesMonitor(
             {
                 ThreadTypes.INFERENCE: read_only_inference_thread_status,
                 ThreadTypes.TRAINING: read_only_training_thread_status,
@@ -437,7 +437,7 @@ class TestThreadStatusesHandler:
     def test_wait_for_all_threads_pause_when_empty_status(self) -> None:
         """Test wait_for_all_threads_pause when statuses is empty."""
         # immediately return True if statuses is empty
-        thread_status_handler = ThreadStatusesHandler(statuses={})
+        thread_status_handler = ThreadStatusesMonitor(statuses={})
         start = time.perf_counter()
         assert thread_status_handler.wait_for_all_threads_pause(0.1) is True
         assert time.perf_counter() - start < 1e-3
@@ -576,7 +576,7 @@ class TestThreadStatusesHandler:
 
     def test_check_all_threads_paused_empty_statuses(self) -> None:
         """Test check_all_threads_paused when statuses is empty."""
-        thread_status_handler = ThreadStatusesHandler(statuses={})
+        thread_status_handler = ThreadStatusesMonitor(statuses={})
         assert thread_status_handler.check_all_threads_paused() is True
 
     @pytest.mark.parametrize(
@@ -612,7 +612,7 @@ class TestThreadStatusesHandler:
 
     def test_check_any_threads_paused_empty_statuses(self) -> None:
         """Test check_any_threads_paused when statuses is empty."""
-        thread_status_handler = ThreadStatusesHandler(statuses={})
+        thread_status_handler = ThreadStatusesMonitor(statuses={})
         assert thread_status_handler.check_any_threads_paused() is False
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
# Pull Request

## 内容

#135 ThreadStatusesHandlerは何もハンドルせず、状態監視をするためのものなので `ThreadStatusesMonitor`に変更しました。

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
