### PR TITLE
基底 Thread クラスにイベントループを実装

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,7 @@ filterwarnings = [
   "ignore::UserWarning",
 ]
 log_cli = "True"
+log_level = "INFO"
 
 minversion = "6.0"
 testpaths = "tests/"

--- a/src/pamiq_core/threads/base.py
+++ b/src/pamiq_core/threads/base.py
@@ -1,7 +1,7 @@
 import logging
-from pamiq_core import time
 from typing import ClassVar
 
+from pamiq_core import time
 from pamiq_core.state_persistence import PersistentStateMixin
 from pamiq_core.utils.reflection import get_class_module_path
 

--- a/src/pamiq_core/threads/base.py
+++ b/src/pamiq_core/threads/base.py
@@ -1,5 +1,5 @@
 import logging
-import time
+from pamiq_core import time
 from typing import ClassVar
 
 from pamiq_core.state_persistence import PersistentStateMixin

--- a/src/pamiq_core/threads/base.py
+++ b/src/pamiq_core/threads/base.py
@@ -1,5 +1,5 @@
 import logging
-from abc import ABC, abstractmethod
+import time
 from typing import ClassVar
 
 from pamiq_core.state_persistence import PersistentStateMixin
@@ -9,16 +9,28 @@ from .thread_control import ThreadEventMixin
 from .thread_types import ThreadTypes
 
 
-class Thread(ABC, PersistentStateMixin, ThreadEventMixin):
+class Thread(PersistentStateMixin, ThreadEventMixin):
     """Base class for all threads.
 
     This class provides a common interface for all threads in the system.
 
     Attributes:
         THREAD_TYPE: The type of the thread. Subclasses must define this class variable.
+        LOOP_DELAY: The delay between each loop iteration in seconds. Default is 1e-6 seconds.
+    Methods:
+        run: The main method that runs the thread.
+        is_running: Returns True if the thread is running, False otherwise.
+        on_start: Called when the thread starts.
+        on_tick: Called on each loop iteration. Main processing logic should be implemented here.
+        on_end: Called when the thread ends.
+        on_exception: Called when an exception occurs in the thread.
+        on_finally: Called when the thread is finally terminated.
+    Raises:
+        AttributeError: If the `THREAD_TYPE` attribute is not defined in the subclass.
     """
 
     THREAD_TYPE: ClassVar[ThreadTypes]
+    LOOP_DELAY: ClassVar[float] = 1e-6  # prevent busy loops (and high CPU usage)
 
     def __init__(self) -> None:
         """Initialize Thread class.
@@ -32,17 +44,55 @@ class Thread(ABC, PersistentStateMixin, ThreadEventMixin):
             )
         self._logger = logging.getLogger(get_class_module_path(self.__class__))
 
-    @abstractmethod
-    def worker(self) -> None:
-        """Please override this method to implement specified procedures."""
-        ...
-
     def run(self) -> None:
-        """Run the thread's worker method."""
+        """The main method that runs the thread.
+
+        The methods `on_start`, `on_tick`, `on_end`, `on_exception`, and `on_finally`
+        are called at the appropriate times during the thread's lifecycle.
+        """
+        self._logger.info(f"Start '{self.THREAD_TYPE.thread_name}' thread.")
         try:
-            self.worker()
+            self.on_start()
+            while self.is_running():
+                self.on_tick()
+                time.sleep(self.LOOP_DELAY)
+            self.on_end()
         except Exception:
             self._logger.exception(
                 f"An exception has occurred in '{self.THREAD_TYPE.thread_name}' thread."
             )
+            self.on_exception()
             raise
+        finally:
+            self.on_finally()
+            self._logger.info(f"End '{self.THREAD_TYPE.thread_name}' thread.")
+
+    def is_running(self) -> bool:
+        """Whether the thread is running or not.
+
+        `on_tick` is called in a loop when this method returns True.
+        """
+        return True  # Return True or override in subclasses
+
+    def on_start(self) -> None:
+        """Called when the thread starts."""
+        pass
+
+    def on_tick(self) -> None:
+        """Called on each loop iteration.
+
+        Main processing logic should be implemented here.
+        """
+        pass
+
+    def on_end(self) -> None:
+        """Called when the thread ends."""
+        pass
+
+    def on_exception(self) -> None:
+        """Called when an exception occurs in the thread."""
+        pass
+
+    def on_finally(self) -> None:
+        """Called when the thread is finally terminated."""
+        pass

--- a/tests/pamiq_core/threads/test_base.py
+++ b/tests/pamiq_core/threads/test_base.py
@@ -55,25 +55,24 @@ class TestThread:
         spy_on_end = mocker.spy(thread, "on_end")
         spy_on_exception = mocker.spy(thread, "on_exception")
         spy_on_finally = mocker.spy(thread, "on_finally")
-        spy_logger_info = mocker.spy(
-            thread._logger, "info"
-        )  # INFO level logs are not being emitted thus test with `assert_has_calls()`.
 
         thread.run()
 
-        # Check method calls
+        # Check method calls and log messages
+        check_log_message(
+            expected_log_message="Start 'control' thread.",
+            log_level="INFO",
+            caplog=caplog,
+        )
         spy_on_start.assert_called_once_with()
         assert spy_on_tick.call_count == 3
         spy_on_end.assert_called_once_with()
         spy_on_exception.assert_not_called()  # not called
         spy_on_finally.assert_called_once_with()
-
-        # Check log calls
-        spy_logger_info.assert_has_calls(
-            [
-                call("Start 'control' thread."),
-                call("End 'control' thread."),
-            ]
+        check_log_message(
+            expected_log_message="End 'control' thread.",
+            log_level="INFO",
+            caplog=caplog,
         )
 
     def test_run_with_exception(self, caplog, mocker) -> None:
@@ -94,29 +93,30 @@ class TestThread:
         spy_on_end = mocker.spy(thread, "on_end")
         spy_on_exception = mocker.spy(thread, "on_exception")
         spy_on_finally = mocker.spy(thread, "on_finally")
-        spy_logger_info = mocker.spy(
-            thread._logger, "info"
-        )  # INFO level logs are not being emitted thus test with `assert_has_calls()`.
 
         with pytest.raises(RuntimeError, match="Test exception"):
             thread.run()
 
-        # Check method calls
+        # Check method calls and log messages
+        check_log_message(
+            expected_log_message="Start 'control' thread.",
+            log_level="INFO",
+            caplog=caplog,
+        )
         spy_on_start.assert_called_once_with()
         spy_on_tick.assert_called_once_with()
         spy_on_end.assert_not_called()  # not called
-        spy_on_exception.assert_called_once_with()
-        spy_on_finally.assert_called_once_with()
-
-        # Check log messages and calls
         check_log_message(
             expected_log_message="An exception has occurred in 'control' thread.",
             log_level="ERROR",
             caplog=caplog,
         )
-        spy_logger_info.assert_has_calls(
-            [
-                call("Start 'control' thread."),
-                call("End 'control' thread."),
-            ]
+        spy_on_exception.assert_called_once_with()
+        spy_on_finally.assert_called_once_with()
+        check_log_message(
+            expected_log_message="An exception has occurred in 'control' thread.",
+            log_level="ERROR",
+            caplog=caplog,
         )
+
+        # Check log messages and calls


### PR DESCRIPTION
# Pull Request

## 内容

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->
threadsモジュール: 基底Threadクラスにイベントループを実装 #142

- Thread クラスにイベントループを実装（既存の `worker()` と `run()` を用いる形式から変更）
- test_base.py のなかの不要コード削除
  - test_init 系の中の `worker()` の override など
  - 仕様変更で不要になったテスト

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

- テスト方針
  - `run()` のテストは、以下の2つとしました
    - `is_running()` が3回だけ True を返し、4回目に False になるクラスを作り、on_xxxx 系の関数が正しい回数呼ばれることを確認
    - `on_tick()` が raise するクラスを作り、on_xxxx 系の関数が正しい回数呼ばれることを確認
    - INFO レベルのログは送出されないので、spy の `assert_has_calls` を利用
- 質問 - docstring について：
  - `Thread` クラスの docstring に method も書いてみました。
  - このクラスにはあっても良いような気もしつつ（一覧性があり見通しが良い）、二重管理になるからやめたほうが良い気もしています。
  - （私の意見としては、二重管理を避けるため、無い方が良いかな？　とは思ったのですが、念の為質問したいと思いまして、今の実装に入れてあります。）
  - いかがでしょうか？