### PR TITLE
TorchTrainingModelでsave_stateとload_stateをoverride

### DIFF
--- a/src/pamiq_core/torch/model.py
+++ b/src/pamiq_core/torch/model.py
@@ -189,7 +189,7 @@ class TorchTrainingModel[T: nn.Module](TrainingModel[TorchInferenceModel[T]]):
         Args:
             path: Path where the states should be saved.
         """
-        torch.save(self.model.state_dict(), path)
+        torch.save(self.model.state_dict(), path)  # pyright: ignore[reportUnknownMemberType]
 
     @override
     def load_state(self, path: Path) -> None:
@@ -198,4 +198,4 @@ class TorchTrainingModel[T: nn.Module](TrainingModel[TorchInferenceModel[T]]):
         Args:
             path: Path where the states should be loaded.
         """
-        self.model.load_state_dict(torch.load(path))
+        self.model.load_state_dict(torch.load(path))  # pyright: ignore[reportUnknownMemberType]

--- a/src/pamiq_core/torch/model.py
+++ b/src/pamiq_core/torch/model.py
@@ -189,7 +189,7 @@ class TorchTrainingModel[T: nn.Module](TrainingModel[TorchInferenceModel[T]]):
         Args:
             path: Path where the states should be saved.
         """
-        torch.save(self.model.state_dict(), f"{path}.pth")  # pyright: ignore[reportUnknownMemberType]
+        torch.save(self.model.state_dict(), f"{path}.pt")  # pyright: ignore[reportUnknownMemberType]
 
     @override
     def load_state(self, path: Path) -> None:
@@ -198,4 +198,4 @@ class TorchTrainingModel[T: nn.Module](TrainingModel[TorchInferenceModel[T]]):
         Args:
             path: Path where the states should be loaded.
         """
-        self.model.load_state_dict(torch.load(f"{path}.pth"))  # pyright: ignore[reportUnknownMemberType]
+        self.model.load_state_dict(torch.load(f"{path}.pt"))  # pyright: ignore[reportUnknownMemberType]

--- a/src/pamiq_core/torch/model.py
+++ b/src/pamiq_core/torch/model.py
@@ -189,7 +189,7 @@ class TorchTrainingModel[T: nn.Module](TrainingModel[TorchInferenceModel[T]]):
         Args:
             path: Path where the states should be saved.
         """
-        torch.save(self.model.state_dict(), path)  # pyright: ignore[reportUnknownMemberType]
+        torch.save(self.model.state_dict(), f"{path}.pth")  # pyright: ignore[reportUnknownMemberType]
 
     @override
     def load_state(self, path: Path) -> None:
@@ -198,4 +198,4 @@ class TorchTrainingModel[T: nn.Module](TrainingModel[TorchInferenceModel[T]]):
         Args:
             path: Path where the states should be loaded.
         """
-        self.model.load_state_dict(torch.load(path))  # pyright: ignore[reportUnknownMemberType]
+        self.model.load_state_dict(torch.load(f"{path}.pth"))  # pyright: ignore[reportUnknownMemberType]

--- a/src/pamiq_core/torch/model.py
+++ b/src/pamiq_core/torch/model.py
@@ -1,4 +1,5 @@
 import copy
+from pathlib import Path
 from threading import RLock
 from typing import Any, Protocol, override
 
@@ -180,3 +181,21 @@ class TorchTrainingModel[T: nn.Module](TrainingModel[TorchInferenceModel[T]]):
     def forward(self, *args: Any, **kwds: Any) -> Any:
         """forward."""
         return self.model(*args, **kwds)
+
+    @override
+    def save_state(self, path: Path) -> None:
+        """Save the model params.
+
+        Args:
+            path: Path where the states should be saved.
+        """
+        torch.save(self.model.state_dict(), path)
+
+    @override
+    def load_state(self, path: Path) -> None:
+        """Load the model params.
+
+        Args:
+            path: Path where the states should be loaded.
+        """
+        self.model.load_state_dict(torch.load(path))

--- a/tests/pamiq_core/torch/test_model.py
+++ b/tests/pamiq_core/torch/test_model.py
@@ -233,6 +233,7 @@ class TestTorchTrainingModel:
     ):
         test_path = tmp_path / "model_params"
         torch_training_model_default.save_state(test_path)
+        assert (tmp_path / "model_params.pth").is_file()
         saved_params = copy.deepcopy(torch_training_model_default.model.state_dict())
         # make differences
         for model_weight in torch_training_model_default.model.parameters():

--- a/tests/pamiq_core/torch/test_model.py
+++ b/tests/pamiq_core/torch/test_model.py
@@ -233,7 +233,7 @@ class TestTorchTrainingModel:
     ):
         test_path = tmp_path / "model_params"
         torch_training_model_default.save_state(test_path)
-        assert (tmp_path / "model_params.pth").is_file()
+        assert (tmp_path / "model_params.pt").is_file()
         saved_params = copy.deepcopy(torch_training_model_default.model.state_dict())
         # make differences
         for model_weight in torch_training_model_default.model.parameters():

--- a/tests/pamiq_core/torch/test_model.py
+++ b/tests/pamiq_core/torch/test_model.py
@@ -231,7 +231,7 @@ class TestTorchTrainingModel:
         torch_training_model_default: TorchTrainingModel,
         tmp_path: Path,
     ):
-        test_path = tmp_path / "model_params.pth"
+        test_path = tmp_path / "model_params"
         torch_training_model_default.save_state(test_path)
         saved_params = copy.deepcopy(torch_training_model_default.model.state_dict())
         # make differences

--- a/tests/pamiq_core/torch/test_model.py
+++ b/tests/pamiq_core/torch/test_model.py
@@ -1,4 +1,6 @@
+import copy
 import logging
+from pathlib import Path
 
 import pytest
 import torch
@@ -223,3 +225,28 @@ class TestTorchTrainingModel:
             is not torch_inference_model._raw_model.weight
         )
         assert torch_inference_model._raw_model.weight.grad is None
+
+    def test_save_and_load_state(
+        self,
+        torch_training_model_default: TorchTrainingModel,
+        tmp_path: Path,
+    ):
+        test_path = tmp_path / "model_params.pth"
+        torch_training_model_default.save_state(test_path)
+        saved_params = copy.deepcopy(torch_training_model_default.model.state_dict())
+        # make differences
+        for model_weight in torch_training_model_default.model.parameters():
+            model_weight.data += 1.0
+        # check if the differences between the models are made correctly.
+        model_params = torch_training_model_default.model.state_dict()
+        assert model_params is not saved_params
+        assert list(model_params.keys()) == list(saved_params.keys())
+        for key in saved_params.keys():
+            assert not torch.equal(model_params[key], saved_params[key])
+        # check if load can be performed correctly.
+        torch_training_model_default.load_state(test_path)
+        loaded_params = torch_training_model_default.model.state_dict()
+        assert loaded_params is not saved_params
+        assert list(loaded_params.keys()) == list(saved_params.keys())
+        for key in saved_params.keys():
+            assert torch.equal(loaded_params[key], saved_params[key])


### PR DESCRIPTION
# Pull Request

## 内容

`TorchTrainingModel`に`save_state`と`load_state`を実装、torchモデルのパラメーターを保存できるようにする

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
