### PR TITLE
Trainerに学習を実行したかを判定するためのフラグを追加

### DIFF
--- a/src/pamiq_core/trainer/base.py
+++ b/src/pamiq_core/trainer/base.py
@@ -138,15 +138,20 @@ class Trainer(ABC, PersistentStateMixin, ThreadEventMixin):
         """Teardown procedure after training."""
         pass
 
-    def run(self) -> None:
-        """Runs the training process if the trainer is trainable."""
+    def run(self) -> bool:
+        """Runs the training process if the trainer is trainable.
+
+        Returns:
+            bool: True if training was executed, False if skipped due to conditions not met.
+        """
         if not self.is_trainable():
-            return
+            return False
 
         self.setup()
         self.train()
         self.sync_models()
         self.teardown()
+        return True
 
     @override
     def save_state(self, path: Path) -> None:

--- a/tests/pamiq_core/trainer/test_base.py
+++ b/tests/pamiq_core/trainer/test_base.py
@@ -129,13 +129,15 @@ class TestTrainer:
         mock_model.sync.assert_called_once_with()
 
     def test_run(self, trainer_attached: TrainerImpl, mocker: MockerFixture) -> None:
+        """Test that run() executes training and returns True."""
         mock_setup = mocker.spy(trainer_attached, "setup")
         mock_train = mocker.spy(trainer_attached, "train")
         mock_sync_models = mocker.spy(trainer_attached, "sync_models")
         mock_teardown = mocker.spy(trainer_attached, "teardown")
 
-        trainer_attached.run()
+        result = trainer_attached.run()
 
+        assert result is True
         mock_setup.assert_called_once_with()
         mock_train.assert_called_once_with()
         mock_sync_models.assert_called_once_with()
@@ -206,7 +208,9 @@ class TestTrainer:
         mock_setup = mocker.spy(conditional_trainer_attached, "setup")
         mock_train = mocker.spy(conditional_trainer_attached, "train")
 
-        conditional_trainer_attached.run()
+        result = conditional_trainer_attached.run()
+        # Verify run returns False when training is skipped
+        assert result is False
 
         # Verify none of the training steps were executed
         mock_setup.assert_not_called()


### PR DESCRIPTION
# Pull Request

## 内容

Trainerが学習を行ったかどうかのフラグを返す機能を実装しました。これにより、学習を実行した時のみ実行時間のログ処理を行う、といったことが可能になります。

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
