### PR TITLE
BaseThread class の実装

### DIFF
--- a/src/pamiq_core/threads/__init__.py
+++ b/src/pamiq_core/threads/__init__.py
@@ -1,4 +1,4 @@
-from .base import Thread
+from .base import BackgroundThread, Thread
 from .thread_control import (
     ControllerCommandHandler,
     ReadOnlyController,
@@ -13,6 +13,7 @@ from .thread_types import (
 )
 
 __all__ = [
+    "BackgroundThread",
     "Thread",
     "ThreadTypes",
     "ThreadController",

--- a/tests/pamiq_core/threads/test_base.py
+++ b/tests/pamiq_core/threads/test_base.py
@@ -3,7 +3,15 @@ from unittest.mock import call
 
 import pytest
 
-from pamiq_core.threads import Thread, ThreadTypes
+from pamiq_core.threads import (
+    BackgroundThread,
+    ControllerCommandHandler,
+    ReadOnlyController,
+    ReadOnlyThreadStatus,
+    Thread,
+    ThreadController,
+    ThreadTypes,
+)
 from tests.helpers import check_log_message
 
 
@@ -120,3 +128,165 @@ class TestThread:
         )
 
         # Check log messages and calls
+
+
+# This class is defined here since it is used in the fixtures in the TestBackgroundThread
+class ValidBackgroundThread(BackgroundThread):
+    """A valid BackgroundThread subclass for testing purposes."""
+
+    THREAD_TYPE = ThreadTypes.INFERENCE
+
+    def __init__(self) -> None:
+        super().__init__()
+
+
+class TestBackgroundThread:
+    @pytest.fixture
+    def background_thread(self) -> ValidBackgroundThread:
+        """Fixture to create a valid BackgroundThread instance."""
+        return ValidBackgroundThread()
+
+    @pytest.fixture
+    def thread_controller(self) -> ThreadController:
+        """Fixture to create a thread controller."""
+        return ThreadController()
+
+    @pytest.fixture
+    def read_only_controller(self, thread_controller) -> ReadOnlyController:
+        """Fixture to create a read-only controller."""
+        return ReadOnlyController(thread_controller)
+
+    @pytest.fixture
+    def controller_command_handler(
+        self, read_only_controller
+    ) -> ControllerCommandHandler:
+        """Fixture to create a ControllerCommandHandler instance."""
+        return ControllerCommandHandler(read_only_controller)
+
+    @pytest.fixture
+    def background_thread_with_controller(
+        self, background_thread, read_only_controller
+    ) -> ValidBackgroundThread:
+        """Fixture to create a BackgroundThread with a controller."""
+        background_thread.attach_controller(read_only_controller)
+        return background_thread
+
+    def test_init_with_THREAD_TYPE_attribute_other_than_control(self) -> None:
+        """Test that the Thread class can be initialized with a THREAD_TYPE
+        attribute other than 'control'."""
+
+        class TestThreadWithAppropriateThreadType(BackgroundThread):
+            THREAD_TYPE = ThreadTypes.INFERENCE
+
+            def __init__(self) -> None:
+                super().__init__()
+
+        _ = TestThreadWithAppropriateThreadType()  # no error should be raised
+
+    def test_init_with_control_THREAD_TYPE(self) -> None:
+        """Test that the Thread class can NOT be initialized with a 'control'
+        THREAD_TYPE attribute."""
+
+        class TestThreadWithControlThreadType(BackgroundThread):
+            THREAD_TYPE = ThreadTypes.CONTROL
+
+            def __init__(self) -> None:
+                super().__init__()
+
+        with pytest.raises(
+            ValueError,
+            match="BackgroundThread cannot be of type 'control'.",
+        ):
+            _ = TestThreadWithControlThreadType()
+
+    def test_thread_status(self, background_thread) -> None:
+        """Test that the thread status returns ReadOnlyThreadStatus
+        instance."""
+        assert isinstance(background_thread.thread_status, ReadOnlyThreadStatus)
+
+    def test_attach_controller(self, background_thread, read_only_controller) -> None:
+        """Test that the controller can be attached to the thread."""
+
+        background_thread.attach_controller(read_only_controller)
+        assert isinstance(
+            background_thread._controller_command_handler, ControllerCommandHandler
+        )
+
+    def test_on_paused(self, background_thread, mocker) -> None:
+        """Test that the on_paused method changes thread status."""
+        background_thread.on_paused()
+
+        assert background_thread.thread_status.is_pause() is True
+
+    def test_on_resumed(self, background_thread, mocker) -> None:
+        """Test that the on_resumed method changes thread status."""
+
+        background_thread.on_resumed()
+
+        assert background_thread.thread_status.is_resume() is True
+
+    def test_start(self, background_thread, mocker) -> None:
+        """Test that the start method actually starts the thread."""
+        spy_thread_start = mocker.spy(background_thread._thread, "start")
+        _ = mocker.patch.object(
+            background_thread, "is_running", return_value=False
+        )  # make this to finish the `run()` method
+
+        background_thread.start()
+
+        spy_thread_start.assert_called_once_with()
+
+    def test_join(self, background_thread, mocker) -> None:
+        """Test that the join method actually joins the thread."""
+        spy_thread_join = mocker.spy(background_thread._thread, "join")
+
+        background_thread.start()
+        background_thread.join()
+
+        spy_thread_join.assert_called_once_with()
+
+    def test_is_alive_when_alive(self, background_thread, mocker) -> None:
+        """Test that the is_alive returns True when the thread is alive."""
+        mocker.patch.object(background_thread._thread, "is_alive", return_value=True)
+
+        assert background_thread.is_alive() is True
+
+    def test_is_alive_when_not_alive(self, background_thread, mocker) -> None:
+        """Test that the is_alive returns False when the thread is not
+        alive."""
+        mocker.patch.object(background_thread._thread, "is_alive", return_value=False)
+
+        assert background_thread.is_alive() is False
+
+    def test_is_running_when_manage_loop_true(
+        self, background_thread_with_controller, mocker
+    ) -> None:
+        """Test that the is_running returns True when
+        `controller_command_handler.manage_loop()` is True."""
+        _ = mocker.patch.object(
+            background_thread_with_controller._controller_command_handler,
+            "manage_loop",
+            return_value=True,
+        )
+
+        assert background_thread_with_controller.is_running() is True
+
+    def test_is_running_when_manage_loop_false(
+        self, background_thread_with_controller, mocker
+    ) -> None:
+        """Test that the is_running returns False when
+        `controller_command_handler.manage_loop()` is False."""
+        _ = mocker.patch.object(
+            background_thread_with_controller._controller_command_handler,
+            "manage_loop",
+            return_value=False,
+        )
+
+        assert background_thread_with_controller.is_running() is False
+
+    def test_on_exception(self, background_thread, mocker) -> None:
+        """Test that the on_exception method changes thread status."""
+
+        background_thread.on_exception()
+
+        assert background_thread.thread_status.is_exception_raised() is True


### PR DESCRIPTION
# Pull Request

## 内容

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

threadsモジュール: BackgroundThreadクラスの実装 #127
- BaseThread class の実装

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

以下3点が主に気になっております、、、！
ご確認いただけますと助かります。
よろしくおねがいします！

- `attach_controller` のテストは、isinstance のテストのみとしました。これで良いでしょうか？
    - 一応、超厳密には、コンストラクタに `self.on_pause` と `self.on_resume` を渡しているということも確認したほうが良い気がしましたが、
    - 流石にそこまでやらなくてもいいという判断で、いまはこの実装になっています。
- `is_alive()`, `is_running()` では、`mocker.patch.object` を用いたテストにしましたが、自身がありません。
    - こうした理由：`is_alive()` は、本質的には、`self._thread` が alive なときは True を返し、not alive なら False を返せばよい。なので、こういうテストにしてみた
    - 自信がない理由：自明なテストになってしまっている気がします。通って当たり前のテストと言うか、、、。`assert_returns` 的なものがあればそれを使いたいですが、そういうのもないので、今の形にしています。
    - レビューいただけますと助かります！
- `on_resume()`, `on_pause()`, `on_exception()` では、`super().on_xxxx()` の実行はテストしていません。
    - 単純な `mocker.spy` がうまく行かないのに加え、
    - super の方では実際には何もやっていないので、
    - こういう実装にしました。