### PR TITLE
制御スレッドをWebApiCommand経由で操作する機能を実装

### DIFF
--- a/src/pamiq_core/threads/__init__.py
+++ b/src/pamiq_core/threads/__init__.py
@@ -1,5 +1,4 @@
 from .base import BackgroundThread, Thread
-from .control_thread import ControlThread
 from .thread_control import (
     ControllerCommandHandler,
     ReadOnlyController,
@@ -24,5 +23,4 @@ __all__ = [
     "ReadOnlyThreadStatus",
     "ThreadStatusesMonitor",
     "ThreadEventMixin",
-    "ControlThread",
 ]


### PR DESCRIPTION
# Pull Request

## 内容

#158 サークルインポートによるエラーが発生したため、`__init__.py`からControlThreadを削除しました。
 またon_startの呼び出し時にinitializeする関係上、いくつかのテストに`on_start`をすでに呼び出し済のインスタンスを渡すように修正しました

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
