### PR TITLE
Agentの中に子エージェントを持つ機能を実装

### DIFF
--- a/docs/user-guide/interaction.md
+++ b/docs/user-guide/interaction.md
@@ -33,6 +33,31 @@ class MyAgent(Agent[list[float], int]):
             return 0
 ```
 
+### Composite Agents
+
+Agents can contain child agents that share the parent's inference models and data collectors. This is useful for building hierarchical decision-making systems or dividing complex agent logic into modular components:
+
+```python
+from pamiq_core import Agent
+
+class MainAgent(Agent[..., ...]):
+    @override
+    def __init__(self) -> None:
+        # Create child agents
+        self.navigation_agent = NavigationAgent()
+        self.perception_agent = PerceptionAgent()
+        self.planning_agent = PlanningAgent()
+
+        # Create parent agent with child agents
+        super().__init__(agents={
+            "navigation": self.navigation_agent,
+            "perception": self.perception_agent,
+            "planning": self.planning_agent
+        })
+```
+
+When models and data collectors are attached to the parent agent, they are automatically propagated to all child agents. State persistence is also handled hierarchically, with each child agent's state being saved and loaded as part of the parent's state.
+
 ### Accessing Inference Models
 
 To access inference models for decision making, override the `on_inference_models_attached` callback:

--- a/docs/user-guide/interaction.md
+++ b/docs/user-guide/interaction.md
@@ -56,7 +56,7 @@ class MainAgent(Agent[..., ...]):
         })
 ```
 
-When models and data collectors are attached to the parent agent, they are automatically propagated to all child agents. State persistence is also handled hierarchically, with each child agent's state being saved and loaded as part of the parent's state.
+When models and data collectors are attached to the parent agent, they are automatically propagated to all child agents. Similarly, system events like pause and resume are also forwarded to all child agents, ensuring consistent state across the hierarchy. State persistence is handled hierarchically as well, with each child agent's state being saved and loaded as part of the parent's state.
 
 ### Accessing Inference Models
 

--- a/src/pamiq_core/interaction/agent.py
+++ b/src/pamiq_core/interaction/agent.py
@@ -23,8 +23,8 @@ class Agent[ObsType, ActType](
     interface that all agent implementations must follow.
 
     Agents can contain child agents that will inherit the parent's
-    inference models and data collectors. State persistence is also
-    propagated to all child agents.
+    inference models and data collectors. State persistence and Thread
+    Event is also propagated to all child agents.
     """
 
     _inference_models: InferenceModelsDict
@@ -37,8 +37,6 @@ class Agent[ObsType, ActType](
             agents: Optional mapping of names to child agents. Child agents will inherit
                 inference models and data collectors from the parent, and their states
                 will be saved and loaded together with the parent.
-
-                NOTE:
         """
         self._agents: Mapping[str, Agent[Any, Any]] = {}
         if agents is not None:
@@ -159,3 +157,23 @@ class Agent[ObsType, ActType](
         super().load_state(path)
         for name, agent in self._agents.items():
             agent.load_state(path / name)
+
+    @override
+    def on_paused(self) -> None:
+        """Handle system pause event.
+
+        Propagates the pause event to all child agents.
+        """
+        super().on_paused()
+        for agent in self._agents.values():
+            agent.on_paused()
+
+    @override
+    def on_resumed(self) -> None:
+        """Handle system resume event.
+
+        Propagates the resume event to all child agents.
+        """
+        super().on_resumed()
+        for agent in self._agents.values():
+            agent.on_resumed()

--- a/src/pamiq_core/interaction/agent.py
+++ b/src/pamiq_core/interaction/agent.py
@@ -1,5 +1,9 @@
+from __future__ import annotations
+
 from abc import ABC, abstractmethod
-from typing import Any
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, override
 
 from pamiq_core.data import DataCollector, DataCollectorsDict
 from pamiq_core.model import InferenceModel, InferenceModelsDict
@@ -17,10 +21,28 @@ class Agent[ObsType, ActType](
     An agent receives observations from an environment and decides on
     actions to take in response. This abstract class defines the
     interface that all agent implementations must follow.
+
+    Agents can contain child agents that will inherit the parent's
+    inference models and data collectors. State persistence is also
+    propagated to all child agents.
     """
 
     _inference_models: InferenceModelsDict
     _data_collectors: DataCollectorsDict
+
+    def __init__(self, agents: Mapping[str, Agent[Any, Any]] | None = None) -> None:
+        """Initialize the agent.
+
+        Args:
+            agents: Optional mapping of names to child agents. Child agents will inherit
+                inference models and data collectors from the parent, and their states
+                will be saved and loaded together with the parent.
+
+                NOTE:
+        """
+        self._agents: Mapping[str, Agent[Any, Any]] = {}
+        if agents is not None:
+            self._agents.update(agents)
 
     @abstractmethod
     def step(self, observation: ObsType) -> ActType:
@@ -39,13 +61,16 @@ class Agent[ObsType, ActType](
 
         This method is called to provide the agent with access to inference models
         for decision making. After attaching, the callback method
-        `on_inference_models_attached` is called.
+        `on_inference_models_attached` is called. If the agent has child agents,
+        the models are also attached to them.
 
         Args:
             inference_models: Dictionary of inference models to attach.
         """
         self._inference_models = inference_models
         self.on_inference_models_attached()
+        for agent in self._agents.values():
+            agent.attach_inference_models(inference_models)
 
     def on_inference_models_attached(self) -> None:
         """Callback method for when inference models are attached to the agent.
@@ -60,13 +85,16 @@ class Agent[ObsType, ActType](
 
         This method is called to provide the agent with access to data collectors
         for collecting experience data. After attaching, the callback method
-        `on_data_collectors_attached` is called.
+        `on_data_collectors_attached` is called. If the agent has child agents,
+        the collectors are also attached to them.
 
         Args:
             data_collectors: Dictionary of data collectors to attach.
         """
         self._data_collectors = data_collectors
         self.on_data_collectors_attached()
+        for agent in self._agents.values():
+            agent.attach_data_collectors(data_collectors)
 
     def on_data_collectors_attached(self) -> None:
         """Callback method for when data collectors are attached to this agent.
@@ -106,3 +134,28 @@ class Agent[ObsType, ActType](
             KeyError: If the collector is already acquired or not found.
         """
         return self._data_collectors.acquire(name)
+
+    @override
+    def save_state(self, path: Path) -> None:
+        """Save the agent's state and the states of any child agents.
+
+        Args:
+            path: Directory path where to save the states.
+        """
+        super().save_state(path)
+        if len(self._agents) == 0:
+            return
+        path.mkdir(exist_ok=True)
+        for name, agent in self._agents.items():
+            agent.save_state(path / name)
+
+    @override
+    def load_state(self, path: Path) -> None:
+        """Load the agent's state and the states of any child agents.
+
+        Args:
+            path: Directory path from where to load the states.
+        """
+        super().load_state(path)
+        for name, agent in self._agents.items():
+            agent.load_state(path / name)

--- a/tests/pamiq_core/interaction/test_agent.py
+++ b/tests/pamiq_core/interaction/test_agent.py
@@ -229,3 +229,35 @@ class TestAgent:
         save_path = tmp_path / "agent_state"
         agent_attached.save_state(save_path)
         assert not save_path.exists()
+
+    def test_on_paused_propagation(
+        self,
+        parent_agent: AgentImpl,
+        child_agent: ChildAgentImpl,
+        mocker: MockerFixture,
+    ):
+        """Test that on_paused event propagates to child agents."""
+        # Spy on the child's on_paused method
+        spy_child_on_paused = mocker.spy(child_agent, "on_paused")
+
+        # Call on_paused on parent
+        parent_agent.on_paused()
+
+        # Verify child's on_paused was called
+        spy_child_on_paused.assert_called_once_with()
+
+    def test_on_resumed_propagation(
+        self,
+        parent_agent: AgentImpl,
+        child_agent: ChildAgentImpl,
+        mocker: MockerFixture,
+    ):
+        """Test that on_resumed event propagates to child agents."""
+        # Spy on the child's on_resumed method
+        spy_child_on_resumed = mocker.spy(child_agent, "on_resumed")
+
+        # Call on_resumed on parent
+        parent_agent.on_resumed()
+
+        # Verify child's on_resumed was called
+        spy_child_on_resumed.assert_called_once_with()

--- a/tests/pamiq_core/interaction/test_agent.py
+++ b/tests/pamiq_core/interaction/test_agent.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import override
 
 import pytest
@@ -28,6 +29,14 @@ class AgentImpl(Agent[str, int]):
     def step(self, observation: str) -> int:
         """Simple implementation that returns a fixed action."""
         return 42
+
+
+class ChildAgentImpl(Agent[None, None]):
+    """Concrete implementation of Agent for testing."""
+
+    @override
+    def step(self, observation: None) -> None:
+        pass
 
 
 class TestAgent:
@@ -94,6 +103,16 @@ class TestAgent:
         agent.attach_data_collectors(data_collectors_dict)
         return agent
 
+    @pytest.fixture
+    def child_agent(self) -> ChildAgentImpl:
+        """Fixture providing a child agent implementation."""
+        return ChildAgentImpl()
+
+    @pytest.fixture
+    def parent_agent(self, child_agent: AgentImpl) -> AgentImpl:
+        """Fixture providing a parent agent with a child agent."""
+        return AgentImpl(agents={"child": child_agent})
+
     def test_attach_inference_models(
         self,
         agent: AgentImpl,
@@ -134,3 +153,79 @@ class TestAgent:
         """Test the step method returns the expected action."""
         action = agent_attached.step("test observation")
         assert action == 42
+
+    def test_attach_inference_models_propagation(
+        self,
+        parent_agent: AgentImpl,
+        child_agent: ChildAgentImpl,
+        mocker: MockerFixture,
+    ):
+        """Test that attaching inference models propagates to child agents."""
+        # Create mock inference model
+        mock_inference_model = mocker.Mock(InferenceModel)
+        inference_models = InferenceModelsDict({"test_model": mock_inference_model})
+
+        # Spy on the child's attach_inference_models method
+        spy_child_attach = mocker.spy(child_agent, "attach_inference_models")
+
+        # Attach to parent
+        parent_agent.attach_inference_models(inference_models)
+
+        # Verify child's method was called with the same models
+        spy_child_attach.assert_called_once_with(inference_models)
+
+    def test_attach_data_collectors_propagation(
+        self,
+        parent_agent: AgentImpl,
+        child_agent: AgentImpl,
+        data_collectors_dict: DataCollectorsDict,
+        mocker: MockerFixture,
+    ):
+        """Test that attaching data collectors propagates to child agents."""
+        # Spy on the child's attach_data_collectors method
+        spy_child_attach = mocker.spy(child_agent, "attach_data_collectors")
+
+        # Attach to parent
+        parent_agent.attach_data_collectors(data_collectors_dict)
+
+        # Verify child's method was called with the same collectors
+        spy_child_attach.assert_called_once_with(data_collectors_dict)
+
+    def test_save_and_load_state_with_child_agents(
+        self,
+        parent_agent: AgentImpl,
+        child_agent: ChildAgentImpl,
+        mocker: MockerFixture,
+        tmp_path: Path,
+    ):
+        """Test saving and loading state with child agents."""
+        # Spy on save and load methods
+        spy_child_save = mocker.spy(child_agent, "save_state")
+        spy_child_load = mocker.spy(child_agent, "load_state")
+
+        # Save state
+        save_path = tmp_path / "agent_state"
+        parent_agent.save_state(save_path)
+        assert save_path.is_dir()
+
+        # Verify child's save_state was called with correct path
+        spy_child_save.assert_called_once_with(save_path / "child")
+
+        # Load state
+        parent_agent.load_state(save_path)
+
+        # Verify child's load_state was called with correct path
+        spy_child_load.assert_called_once_with(save_path / "child")
+
+    def test_save_and_load_state_no_child_agents(
+        self,
+        agent_attached: AgentImpl,
+        tmp_path: Path,
+    ):
+        """Test saving and loading state with child agents."""
+        # Spy on save and load methods
+
+        # Save state
+        save_path = tmp_path / "agent_state"
+        agent_attached.save_state(save_path)
+        assert not save_path.exists()


### PR DESCRIPTION
# Pull Request

## 内容

旧AMIシステムにおいてAgentが持っていた機能をpamiq-coreにも移植しました。相違点としては、子エージェントにも名前付けが必須になったことです。これにより、自動的に状態の保存を行います。
<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
