### PR TITLE
DataUsersDictの`__setitem__` メソッドを修正

### DIFF
--- a/src/pamiq_core/data/container.py
+++ b/src/pamiq_core/data/container.py
@@ -49,7 +49,7 @@ class DataUsersDict(UserDict[str, DataUser[Any]], PersistentStateMixin):
             item: DataUser instance to add to the dictionary.
         """
         super().__setitem__(key, item)
-        self._data_collectors_dict[key] = DataCollector(item)
+        self._data_collectors_dict[key] = item._collector  # pyright: ignore[reportPrivateUsage]
 
     @classmethod
     def from_data_buffers(

--- a/tests/pamiq_core/data/test_container.py
+++ b/tests/pamiq_core/data/test_container.py
@@ -25,6 +25,12 @@ class TestDataUsersDictAndCollectorsDict:
     def collectors_dict(self, users_dict: DataUsersDict) -> DataCollectorsDict:
         return users_dict.data_collectors_dict
 
+    def test_setitem(
+        self, users_dict: DataUsersDict, collectors_dict: DataCollectorsDict
+    ):
+        assert users_dict["main"]._collector is collectors_dict["main"]
+        assert users_dict["sub"]._collector is collectors_dict["sub"]
+
     # DataUsersDict initialization tests
     def test_from_data_buffers_dict(self, buffers: dict[str, MockDataBuffer]):
         users_dict = DataUsersDict.from_data_buffers(buffers)

--- a/tests/pamiq_core/trainer/test_base.py
+++ b/tests/pamiq_core/trainer/test_base.py
@@ -4,7 +4,7 @@ from typing import override
 import pytest
 from pytest_mock import MockerFixture
 
-from pamiq_core.data import DataUser, DataUsersDict
+from pamiq_core.data import DataCollector, DataUser, DataUsersDict
 from pamiq_core.model import InferenceModel, TrainingModel, TrainingModelsDict
 from pamiq_core.state_persistence import PersistentStateMixin
 from pamiq_core.thread import ThreadEventMixin
@@ -49,6 +49,7 @@ class TestTrainer:
         # Configure mock for trainability tests
         user.__len__.return_value = 100  # Mock buffer size
         user.count_data_added_since.return_value = 10  # Mock new data count
+        user._collector = mocker.MagicMock(DataCollector)
         return user
 
     @pytest.fixture


### PR DESCRIPTION
# Pull Request

## 内容

DataCollectorsDictに受け渡すときに全く別のインスタンスを作成して登録していたので、DataUserが保持するDataCollectorを渡すように修正しました。

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
