### PR TITLE
テスト用のMockクラスを取得するテストヘルパー関数を実装

### DIFF
--- a/docs/api/testing.md
+++ b/docs/api/testing.md
@@ -1,2 +1,3 @@
 ::: pamiq_core.testing.connect_components
 ::: pamiq_core.testing.ConnectedComponents
+::: pamiq_core.testing.create_mock_models

--- a/docs/api/testing.md
+++ b/docs/api/testing.md
@@ -1,3 +1,4 @@
 ::: pamiq_core.testing.connect_components
 ::: pamiq_core.testing.ConnectedComponents
 ::: pamiq_core.testing.create_mock_models
+::: pamiq_core.testing.create_mock_buffer

--- a/docs/user-guide/testing.md
+++ b/docs/user-guide/testing.md
@@ -55,6 +55,22 @@ assert training_model.has_inference_model is True
 assert training_model.inference_model is inference_model
 ```
 
+### Create Mock Buffer
+
+When testing components that require data buffers, you can quickly create mock buffer instances using the `create_mock_buffer` function:
+
+```python
+from pamiq_core.testing import create_mock_buffer
+
+
+buffers = {
+    # Create a default buffer with max_size=1
+    "buffer": create_mock_buffer(),
+    # Create a buffer with custom max_size
+    "large_buffer": create_mock_buffer(max_size=1000),
+}
+```
+
 ### API Reference
 
 For more detailed information, check out the [API Reference](../api/testing.md)

--- a/docs/user-guide/testing.md
+++ b/docs/user-guide/testing.md
@@ -34,6 +34,27 @@ inference_models = components.inference_models
 
 The function returns a `ConnectedComponents` named tuple containing all the connected component dictionaries for easy access in your tests.
 
+### Create Mock Models
+
+When testing components that interact with models, you often need mock implementations of `TrainingModel` and `InferenceModel`. The `create_mock_models` function creates pre-configured mock model pairs:
+
+```python
+from pamiq_core.testing import create_mock_models
+
+# Create a standard model pair
+training_model, inference_model = create_mock_models()
+
+# Create a training model without inference model
+training_model_no_inference, _ = create_mock_models(has_inference_model=False)
+
+# Create an inference-thread-only model
+inference_only_model, inference_model = create_mock_models(inference_thread_only=True)
+
+# Use in tests
+assert training_model.has_inference_model is True
+assert training_model.inference_model is inference_model
+```
+
 ### API Reference
 
 For more detailed information, check out the [API Reference](../api/testing.md)

--- a/docs/user-guide/testing.md
+++ b/docs/user-guide/testing.md
@@ -34,7 +34,7 @@ inference_models = components.inference_models
 
 The function returns a `ConnectedComponents` named tuple containing all the connected component dictionaries for easy access in your tests.
 
-### Create Mock Models
+### Creating Mock Models
 
 When testing components that interact with models, you often need mock implementations of `TrainingModel` and `InferenceModel`. The `create_mock_models` function creates pre-configured mock model pairs:
 
@@ -55,7 +55,7 @@ assert training_model.has_inference_model is True
 assert training_model.inference_model is inference_model
 ```
 
-### Create Mock Buffer
+### Creating Mock Buffer
 
 When testing components that require data buffers, you can quickly create mock buffer instances using the `create_mock_buffer` function:
 

--- a/src/pamiq_core/testing.py
+++ b/src/pamiq_core/testing.py
@@ -1,9 +1,15 @@
 from collections.abc import Mapping
 from typing import Any, NamedTuple
+from unittest.mock import Mock
 
 from .data import DataBuffer, DataCollectorsDict, DataUsersDict
 from .interaction import Agent
-from .model import InferenceModelsDict, TrainingModel, TrainingModelsDict
+from .model import (
+    InferenceModel,
+    InferenceModelsDict,
+    TrainingModel,
+    TrainingModelsDict,
+)
 from .trainer import Trainer, TrainersDict
 
 
@@ -74,3 +80,27 @@ def connect_components(
         training_models=training_models,
         inference_models=inference_models,
     )
+
+
+def create_mock_models(
+    has_inference_model: bool = True, inference_thread_only: bool = False
+) -> tuple[Mock, Mock]:
+    """Create mock training and inference models for testing.
+
+    Creates mocked instances of TrainingModel and InferenceModel with the specified
+    configuration, properly connecting them when has_inference_model is True.
+
+    Args:
+        has_inference_model: Whether the training model should have an inference model
+        inference_thread_only: Whether the model is for inference thread only
+
+    Returns:
+        A tuple containing (training_model, inference_model) mocks
+    """
+    training_model = Mock(TrainingModel)
+    inference_model = Mock(InferenceModel)
+    training_model.has_inference_model = has_inference_model
+    training_model.inference_thread_only = inference_thread_only
+    if has_inference_model:
+        training_model.inference_model = inference_model
+    return training_model, inference_model

--- a/src/pamiq_core/testing.py
+++ b/src/pamiq_core/testing.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping
 from typing import Any, NamedTuple
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 from .data import DataBuffer, DataCollectorsDict, DataUsersDict
 from .interaction import Agent
@@ -104,3 +104,21 @@ def create_mock_models(
     if has_inference_model:
         training_model.inference_model = inference_model
     return training_model, inference_model
+
+
+def create_mock_buffer(max_size: int = 1) -> MagicMock:
+    """Create a mock data buffer for testing.
+
+    Creates a MagicMock instance that mocks a DataBuffer with the specified
+    max_size parameter. This is useful for testing components that depend on
+    DataBuffer without implementing a full buffer.
+
+    Args:
+        max_size: Maximum size of the buffer. Defaults to 1.
+
+    Returns:
+        A MagicMock object that mocks a DataBuffer.
+    """
+    buf = MagicMock(DataBuffer)
+    buf.max_size = max_size
+    return buf

--- a/tests/pamiq_core/test_testing.py
+++ b/tests/pamiq_core/test_testing.py
@@ -12,6 +12,7 @@ from pamiq_core.model import (
 from pamiq_core.testing import (
     ConnectedComponents,
     connect_components,
+    create_mock_buffer,
     create_mock_models,
 )
 from pamiq_core.trainer import Trainer
@@ -169,7 +170,7 @@ class TestConnectComponents:
         assert "model1" in result.inference_models
 
 
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock
 
 
 class TestCreateMockModels:
@@ -209,3 +210,24 @@ class TestCreateMockModels:
         assert training_model.has_inference_model is True
         assert training_model.inference_thread_only is True
         assert training_model.inference_model is inference_model
+
+
+class TestCreateMockBuffer:
+    """Test suite for create_mock_buffer helper function."""
+
+    def test_default_configuration(self) -> None:
+        """Test create_mock_buffer with default parameters."""
+        buffer = create_mock_buffer()
+
+        # Verify buffer is correctly configured
+        assert buffer.max_size == 1
+        assert isinstance(buffer, MagicMock)
+        assert isinstance(buffer, DataBuffer)
+
+    def test_custom_max_size(self) -> None:
+        """Test create_mock_buffer with custom max_size."""
+        custom_size = 100
+        buffer = create_mock_buffer(max_size=custom_size)
+
+        # Verify buffer has the specified max_size
+        assert buffer.max_size == custom_size

--- a/tests/pamiq_core/test_testing.py
+++ b/tests/pamiq_core/test_testing.py
@@ -9,7 +9,11 @@ from pamiq_core.model import (
     TrainingModel,
     TrainingModelsDict,
 )
-from pamiq_core.testing import ConnectedComponents, connect_components
+from pamiq_core.testing import (
+    ConnectedComponents,
+    connect_components,
+    create_mock_models,
+)
 from pamiq_core.trainer import Trainer
 
 
@@ -163,3 +167,45 @@ class TestConnectComponents:
         assert "buffer1" in result.data_collectors
         assert "model1" in result.training_models
         assert "model1" in result.inference_models
+
+
+from unittest.mock import Mock
+
+
+class TestCreateMockModels:
+    """Test suite for create_mock_models helper function."""
+
+    def test_default_configuration(self) -> None:
+        """Test create_mock_models with default parameters."""
+        # Default values: has_inference_model=True, inference_thread_only=False
+        training_model, inference_model = create_mock_models()
+
+        # Verify the models are correctly configured
+        assert training_model.has_inference_model is True
+        assert training_model.inference_thread_only is False
+        assert training_model.inference_model is inference_model
+        assert isinstance(training_model, Mock)
+        assert isinstance(inference_model, Mock)
+        assert isinstance(training_model, TrainingModel)
+        assert isinstance(inference_model, InferenceModel)
+
+    def test_without_inference_model(self) -> None:
+        """Test create_mock_models with has_inference_model=False."""
+        training_model, inference_model = create_mock_models(has_inference_model=False)
+
+        # Verify the training model doesn't have an inference model
+        assert training_model.has_inference_model is False
+        assert training_model.inference_thread_only is False
+        assert training_model.inference_model != inference_model
+        assert isinstance(inference_model, Mock)
+
+    def test_inference_thread_only(self) -> None:
+        """Test create_mock_models with inference_thread_only=True."""
+        training_model, inference_model = create_mock_models(
+            has_inference_model=True, inference_thread_only=True
+        )
+
+        # Verify inference_thread_only is correctly set
+        assert training_model.has_inference_model is True
+        assert training_model.inference_thread_only is True
+        assert training_model.inference_model is inference_model


### PR DESCRIPTION
# Pull Request

## 内容

pamiq-coreを利用したシステムにおけるテストを行う上で、 少しpre-configuredとしたDataBufferやModelのモック生成する必要が出るため、それを簡単に生成するヘルパー関数を実装しました。

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
