### PR TITLE
add VAETrainer for VAE sample

### DIFF
--- a/samples/vae-torch/trainer.py
+++ b/samples/vae-torch/trainer.py
@@ -1,0 +1,164 @@
+# [Original design principles]
+# Trainer class is used to train a model by implementing:
+# - `on_training_models_attached`: Prepare the training models as instance variables.
+# - `on_data_users_attached`: Prepare the data user as instance variable.
+# - `create_optimizers`: Create optimizers for the training models.
+# - `train`: Train the model by using instance variables and optimizers, prepared before.
+#
+# [Outline of this implementation]
+# In this VAE example, all the functions are implemented in the same way as the original design principles.
+
+import itertools
+from typing import override
+
+import torch
+import torch.nn.functional as F
+from model import Decoder, Encoder
+from torch.utils.data import DataLoader, TensorDataset
+from torch.utils.tensorboard.writer import SummaryWriter
+
+from pamiq_core.torch import OptimizersSetup, TorchTrainer, get_device
+
+
+class VAETrainer(TorchTrainer):
+    """Trainer used for this sample."""
+
+    @override
+    def __init__(
+        self,
+        max_epochs: int,
+        batch_size: int,
+        lr: float = 1e-3,
+        log_dir: str | None = None,
+    ) -> None:
+        """Initialize the VAE trainer.
+
+        Args:
+            max_epochs: Maximum number of training epochs.
+            batch_size: Size of the training batch.
+            lr: Learning rate for the optimizer.
+            log_dir: Directory for TensorBoard logs. If None, uses default.
+        """
+
+        super().__init__(
+            training_condition_data_user="observation",
+            min_buffer_size=batch_size,
+            min_new_data_count=batch_size,
+        )
+        self.max_epochs = max_epochs
+        self.batch_size = batch_size
+        self.lr = lr
+
+        # TensorBoard writer
+        self.writer = SummaryWriter(log_dir=log_dir) if log_dir else SummaryWriter()
+
+    @override
+    def on_training_models_attached(self) -> None:
+        """Prepare the encoder and decoder models as instance variables."""
+        super().on_training_models_attached()
+        self.encoder = self.get_torch_training_model("encoder", Encoder)
+        self.decoder = self.get_torch_training_model("decoder", Decoder)
+        # Warn not to unwrap by accessing the `.model` attribute (as it will prevent synchronization)
+
+    @override
+    def on_data_users_attached(self) -> None:
+        """Prepare the data user as an instance variable."""
+        super().on_data_users_attached()
+        self.data_user = self.get_data_user("observation")
+
+    @override
+    def create_optimizers(self) -> OptimizersSetup:
+        params = itertools.chain(
+            self.encoder.model.parameters(),
+            self.decoder.model.parameters(),
+        )
+        """Create optimizers for the encoder and decoder models.
+
+        Returns:
+            OptimizersSetup: A dictionary containing the optimizer for the VAE.
+        """
+        self.optim = torch.optim.Adam(params, lr=self.lr)
+        return {"optimizer": self.optim}
+
+    @override
+    def train(self) -> None:
+        """Train the VAE model using the provided data.
+
+        This method retrieves the training data, sets up a DataLoader,
+        and performs the training loop, including forward passes, loss
+        computation, and backpropagation. It logs the training metrics
+        to TensorBoard.
+        """
+        data = self.data_user.get_data()["data"]
+        dataset = TensorDataset(torch.stack(list(data)))
+        dataloader = DataLoader(dataset, batch_size=self.batch_size, shuffle=True)
+
+        device = get_device(self.encoder.model)
+
+        batch_steps = 0
+
+        # Training loop for ordinary VAE
+        for epoch in range(self.max_epochs):
+            recon_sum = 0.0
+            kl_sum = 0.0
+            data_count = 0
+            for (batch,) in dataloader:
+                batch = batch.to(device)
+
+                # Forward pass
+                dist = self.encoder(batch)
+                z = self.decoder(dist.rsample())
+                recon = self.decoder(z)
+
+                # Reconstruction loss (L2 / MSE)
+                recon_loss = 0.5 * F.mse_loss(
+                    recon, batch, reduction="sum"
+                )  # Using half the MSE loss corresponds to
+                # assuming the decoder's output distribution has unit variance
+                # (i.e., N(recon, I)).
+
+                # KL divergence for Normal
+                mu = dist.loc
+                logvar = 2 * torch.log(dist.scale)
+                kl_loss = -0.5 * torch.sum(1 + logvar - mu.pow(2) - dist.scale.pow(2))
+
+                # Total loss
+                loss = recon_loss + kl_loss
+
+                # Backprop
+                self.optim.zero_grad()
+                loss.backward()
+                self.optim.step()
+
+                # accumulate metrics
+                batch_size = batch.size(0)
+                recon_sum += recon_loss.item()
+                kl_sum += kl_loss.item()
+                data_count += batch_size
+
+                # log per batch
+                self.writer.add_scalar(
+                    "Loss/Total/Batch", loss.item() / batch_size, batch_steps
+                )
+                self.writer.add_scalar(
+                    "Loss/Reconstruction/Batch",
+                    recon_loss.item() / batch_size,
+                    batch_steps,
+                )
+                self.writer.add_scalar(
+                    "Loss/KL/Batch", kl_loss.item() / batch_size, batch_steps
+                )
+                batch_steps += 1
+
+            # accumulate metrics per epoch
+            avg_total = (recon_sum + kl_sum) / data_count
+            avg_recon = recon_sum / data_count
+            avg_kl = kl_sum / data_count
+
+            # log per epoch
+            self.writer.add_scalar("Loss/Total/Epoch", avg_total, epoch)
+            self.writer.add_scalar("Loss/Reconstruction/Epoch", avg_recon, epoch)
+            self.writer.add_scalar("Loss/KL/Epoch", avg_kl, epoch)
+
+        # close writer after training
+        self.writer.close()


### PR DESCRIPTION
# Pull Request

## 内容

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

#192 
VAE sample の VAETrainer を追加

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [x] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->

- l93 の `dataset = TensorDataset(torch.stack(list(data)))` に変更を入れました。
  - もともと `torch.stack()` に `data` を入れていましたが、 `list(data)` を入れています。
  本当はちゃんと `data` は list なので不要ですが、`make run` の formatter に怒られたので、明示的に list になるように修正しました。
- reconstruction loss (`recon_loss`) は、MSE の半分にしてあります
  - こうすると、Decoder が出す確率分布が、分散1の正規分布である場合に対応します