### PR TITLE
Launch関数の`save_state_interval`を`save_state_condition`にリファクタリング

### DIFF
--- a/docs/api/state_persistence.md
+++ b/docs/api/state_persistence.md
@@ -1,3 +1,4 @@
 ::: pamiq_core.state_persistence.PersistentStateMixin
 ::: pamiq_core.state_persistence.StateStore
+::: pamiq_core.state_persistence.PeriodicSaveCondition
 ::: pamiq_core.state_persistence.LatestStatesKeeper

--- a/docs/user-guide/launch.md
+++ b/docs/user-guide/launch.md
@@ -37,11 +37,8 @@ launch(
 To speed up time for faster training:
 
 ```python
-from pamiq_core.state_persistence import PeriodicSaveCondition
-
 config = LaunchConfig(
-    time_scale=10.0,  # Run at 10x speed
-    save_state_condition=PeriodicSaveCondition(300.0)  # Save every 5 minutes
+    time_scale=10.0  # Run at 10x speed
 )
 ```
 

--- a/docs/user-guide/launch.md
+++ b/docs/user-guide/launch.md
@@ -37,9 +37,11 @@ launch(
 To speed up time for faster training:
 
 ```python
+from pamiq_core.state_persistence import PeriodicSaveCondition
+
 config = LaunchConfig(
     time_scale=10.0,  # Run at 10x speed
-    save_state_interval=300.0  # Save every 5 minutes
+    save_state_condition=PeriodicSaveCondition(300.0)  # Save every 5 minutes
 )
 ```
 
@@ -58,6 +60,8 @@ config = LaunchConfig(
 To save system state for later resumption:
 
 ```python
+from pamiq_core.state_persistence import PeriodicSaveCondition
+
 # Initial run
 launch(
     interaction=interaction,
@@ -66,7 +70,7 @@ launch(
     trainers=trainers,
     config=LaunchConfig(
         states_dir="./saved_states",
-        save_state_interval=600.0  # Save every 10 minutes
+        save_state_condition=PeriodicSaveCondition(600.0)  # Save every 10 minutes
     )
 )
 

--- a/docs/user-guide/state_persistence.md
+++ b/docs/user-guide/state_persistence.md
@@ -117,12 +117,13 @@ This organized structure makes it easy to inspect and manage saved states.
 
 The state persistence system in PAMIQ-Core automatically manages state directories:
 
-- States are saved at regular intervals as specified in the `LaunchConfig`
+- States are saved based on the `save_state_condition` specified in the `LaunchConfig`
 - Old states can be automatically cleaned up based on the `max_keep_states` parameter
 - States can be loaded during system launch using the `saved_state_path` parameter
 
 ```python
 from pamiq_core import launch, LaunchConfig
+from pamiq_core.state_persistence import PeriodicSaveCondition
 
 # Launch with automatic state saving every 5 minutes, keeping the 10 most recent states
 launch(
@@ -132,9 +133,39 @@ launch(
     trainers=trainers,
     config=LaunchConfig(
         states_dir="./saved_states",
-        save_state_interval=300.0,  # 5 minutes
+        save_state_condition=PeriodicSaveCondition(300.0),  # Save every 5 minutes
         max_keep_states=10
     )
+)
+```
+
+### Save State Conditions
+
+The `save_state_condition` parameter accepts any callable that returns a boolean. When `True`, the system will save its state. PAMIQ-Core provides built-in conditions:
+
+**PeriodicSaveCondition**: Saves state at regular time intervals
+
+```python
+from pamiq_core.state_persistence import PeriodicSaveCondition
+
+config = LaunchConfig(
+    save_state_condition=PeriodicSaveCondition(300.0)  # Every 5 minutes
+)
+```
+
+**Custom Conditions**: You can create custom conditions
+
+```python
+from pamiq_core import time
+
+# Save state at specific wall clock times (e.g., every hour on the hour)
+def save_on_the_hour():
+    current_time = time.time()
+    minutes_elapsed = (current_time % 3600) / 60  # Minutes past the hour
+    return minutes_elapsed < 0.1  # True for the first 6 seconds of each hour
+
+config = LaunchConfig(
+    save_state_condition=save_on_the_hour
 )
 ```
 

--- a/src/pamiq_core/launcher.py
+++ b/src/pamiq_core/launcher.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -25,8 +25,8 @@ class LaunchConfig:
         states_dir: Directory path where states will be saved.
         state_name_format: Format string for state directory names.
         saved_state_path: Optional path to a previously saved state to load at startup.
-        save_state_interval: Interval in seconds between automatic state saves.
-            Use infinity for no automatic saves.
+        save_state_condition: Optional callable that returns True when state should be saved.
+            If None, state will never be saved automatically.
         max_keep_states: Maximum number of state directories to keep in the states directory.
             Older state directories beyond this number will be automatically removed.
             Use -1 to disable this feature (no automatic removal).
@@ -49,7 +49,7 @@ class LaunchConfig:
     states_dir: str | Path = Path("./states")
     state_name_format: str = "%Y-%m-%d_%H-%M-%S,%f.state"
     saved_state_path: str | Path | None = None
-    save_state_interval: float = float("inf")
+    save_state_condition: Callable[[], bool] | None = None
     max_keep_states: int = -1
     state_name_pattern: str = "*.state"
     states_cleanup_interval: float = 60.0
@@ -130,7 +130,7 @@ def launch(
     # Initialize threads
     control_thread = ControlThread(
         state_store,
-        save_state_interval=config.save_state_interval,
+        save_state_condition=config.save_state_condition,
         timeout_for_all_threads_pause=config.timeout_for_all_threads_pause,
         max_attempts_to_pause_all_threads=config.max_attempts_to_pause_all_threads,
         max_uptime=config.max_uptime,

--- a/src/pamiq_core/state_persistence.py
+++ b/src/pamiq_core/state_persistence.py
@@ -126,6 +126,36 @@ def load_pickle(path: Path | str) -> Any:
         return pickle.load(f)
 
 
+class PeriodicSaveCondition:
+    """Save state condition based on periodic time intervals.
+
+    This condition triggers state saving at regular time intervals.
+    """
+
+    def __init__(self, interval: float) -> None:
+        """Initializes PeriodicSaveCondition.
+
+        Args:
+            interval: Time interval in seconds between state saves.
+        """
+        # Import here to avoid circular dependency
+        from .utils.schedulers import TimeIntervalScheduler
+
+        self._flag = False
+
+        def set_true() -> None:
+            self._flag = True
+
+        self._scheduler = TimeIntervalScheduler(interval, set_true)
+
+    def __call__(self) -> bool:
+        """Check if interval has elapsed and state should be saved."""
+        self._scheduler.update()
+        # get return value and reset flag.
+        out, self._flag = self._flag, False
+        return out
+
+
 class LatestStatesKeeper:
     """Keeps a fixed number of state directories by removing older ones.
 

--- a/tests/pamiq_core/test_state_persistence.py
+++ b/tests/pamiq_core/test_state_persistence.py
@@ -7,6 +7,7 @@ from pytest_mock import MockerFixture
 
 from pamiq_core.state_persistence import (
     LatestStatesKeeper,
+    PeriodicSaveCondition,
     PersistentStateMixin,
     StateStore,
     load_pickle,
@@ -249,3 +250,49 @@ class TestLatestStatesKeeper:
 
         # Verify cleanup was called directly
         mock_cleanup.assert_called_once()
+
+
+class TestPeriodicSaveCondition:
+    """Test the PeriodicSaveCondition class."""
+
+    def test_initial_state_returns_false(self) -> None:
+        """Test that condition returns False initially."""
+        condition = PeriodicSaveCondition(interval=1.0)
+        assert condition() is False
+
+    def test_returns_true_after_interval(self) -> None:
+        """Test that condition returns True after interval has elapsed."""
+        import time
+
+        # Use very short interval for testing
+        interval = 0.01
+        condition = PeriodicSaveCondition(interval=interval)
+
+        # First call should return False
+        assert condition() is False
+
+        # Wait for interval to elapse
+        time.sleep(interval * 1.5)
+
+        # Should now return True
+        assert condition() is True
+
+    def test_multiple_intervals(self) -> None:
+        """Test behavior across multiple intervals."""
+        import time
+
+        interval = 0.01
+        condition = PeriodicSaveCondition(interval=interval)
+
+        # Initial state
+        assert condition() is False
+
+        # First interval
+        time.sleep(interval * 1.5)
+        assert condition() is True
+        assert condition() is False
+
+        # Second interval
+        time.sleep(interval * 1.5)
+        assert condition() is True
+        assert condition() is False


### PR DESCRIPTION
# Pull Request

#279 任意の保存処理実行条件を設定可能にするために，LaunchConfigの`save_state_interval`を`save_state_condition`に変更し，従来の実装は `PeriodicSaveCondition`に変更しました．

ドキュメントの更新もしています．

## 内容

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [ ] なし
- [x] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
