### PR TITLE
Dataモジュールのtypingの柔軟性を向上

### DIFF
--- a/docs/user-guide/data.md
+++ b/docs/user-guide/data.md
@@ -106,7 +106,7 @@ Here's an example of a simple custom buffer:
 from pamiq_core.data import DataBuffer
 from typing import override
 
-class SimpleBuffer[T](DataBuffer[T]):
+class SimpleBuffer[T](DataBuffer[T, dict[str, list[T]]]):
     """A simple buffer that stores data in lists."""
 
     @override
@@ -162,6 +162,15 @@ class SimpleBuffer[T](DataBuffer[T]):
         """
         return self._count
 ```
+
+!!! note "DataBuffer Type Parameters"
+
+    All DataBuffer implementations have two type parameters:
+
+    - `T`: The type of data stored in each step
+    - `R`: The return type of the `get_data()` method
+
+    For example, `SequentialBuffer[T]` is actually `DataBuffer[T, dict[str, list[T]]]`, meaning it returns a dictionary mapping field names to lists of values.
 
 ## Built-in DataBuffers
 

--- a/src/pamiq_core/__init__.py
+++ b/src/pamiq_core/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from importlib import metadata
 
-from . import data, interaction, model, time, trainer, utils
+from . import data, interaction, model, time, trainer, typing, utils
 from .data import DataBuffer, DataCollector, DataUser
 from .interaction import (
     Actuator,
@@ -37,6 +37,7 @@ __all__ = [
     "time",
     "trainer",
     "utils",
+    "typing",
     "DataBuffer",
     "DataCollector",
     "DataUser",

--- a/src/pamiq_core/data/__init__.py
+++ b/src/pamiq_core/data/__init__.py
@@ -1,5 +1,5 @@
 from . import impls
-from .buffer import BufferData, DataBuffer, StepData
+from .buffer import DataBuffer, StepData
 from .container import DataCollectorsDict, DataUsersDict
 from .interface import DataCollector, DataUser
 
@@ -7,7 +7,6 @@ __all__ = [
     "impls",
     "DataBuffer",
     "StepData",
-    "BufferData",
     "DataCollector",
     "DataUser",
     "DataCollectorsDict",

--- a/src/pamiq_core/data/buffer.py
+++ b/src/pamiq_core/data/buffer.py
@@ -4,10 +4,9 @@ from collections.abc import Iterable, Mapping
 from pamiq_core.state_persistence import PersistentStateMixin
 
 type StepData[T] = Mapping[str, T]
-type BufferData[T] = Mapping[str, Iterable[T]]
 
 
-class DataBuffer[T](ABC, PersistentStateMixin):
+class DataBuffer[T, R](ABC, PersistentStateMixin):
     """Interface for managing experience data collected during system
     execution.
 
@@ -15,6 +14,10 @@ class DataBuffer[T](ABC, PersistentStateMixin):
     experience data generated during system execution. It maintains a
     buffer of fixed maximum size that stores data for specified data
     names.
+
+    Type Parameters:
+        T: The type of data stored in each step.
+        R: The return type of the get_data() method.
     """
 
     def __init__(self, collecting_data_names: Iterable[str], max_size: int) -> None:
@@ -54,12 +57,11 @@ class DataBuffer[T](ABC, PersistentStateMixin):
         pass
 
     @abstractmethod
-    def get_data(self) -> BufferData[T]:
+    def get_data(self) -> R:
         """Retrieves all stored data from the buffer.
 
         Returns:
-            Dictionary mapping data field names to sequences of their values.
-            Each sequence has the same length.
+            Data structure containing all stored samples.
         """
         pass
 

--- a/src/pamiq_core/data/container.py
+++ b/src/pamiq_core/data/container.py
@@ -11,7 +11,7 @@ from .buffer import DataBuffer
 from .interface import DataCollector, DataUser
 
 
-class DataUsersDict(UserDict[str, DataUser[Any]], PersistentStateMixin):
+class DataUsersDict(UserDict[str, DataUser[Any, Any]], PersistentStateMixin):
     """A dictionary mapping names to data users with helper methods for
     collector management.
 
@@ -37,7 +37,7 @@ class DataUsersDict(UserDict[str, DataUser[Any]], PersistentStateMixin):
         return self._data_collectors_dict
 
     @override
-    def __setitem__(self, key: str, item: DataUser[Any]) -> None:
+    def __setitem__(self, key: str, item: DataUser[Any, Any]) -> None:
         """Set a data user in the dictionary and create its associated
         collector.
 
@@ -54,9 +54,9 @@ class DataUsersDict(UserDict[str, DataUser[Any]], PersistentStateMixin):
     @classmethod
     def from_data_buffers(
         cls,
-        buffer_map: Mapping[str, DataBuffer[Any]] | None = None,
+        buffer_map: Mapping[str, DataBuffer[Any, Any]] | None = None,
         /,
-        **kwds: DataBuffer[Any],
+        **kwds: DataBuffer[Any, Any],
     ) -> Self:
         """Creates a DataUsersDict from a mapping of data buffers.
 
@@ -67,7 +67,7 @@ class DataUsersDict(UserDict[str, DataUser[Any]], PersistentStateMixin):
         Returns:
             New DataUsersDict instance with users created from buffers.
         """
-        data: dict[str, DataBuffer[Any]] = {}
+        data: dict[str, DataBuffer[Any, Any]] = {}
         if buffer_map is not None:
             data.update(buffer_map)
         if len(kwds) > 0:

--- a/src/pamiq_core/data/container.py
+++ b/src/pamiq_core/data/container.py
@@ -102,7 +102,7 @@ class DataUsersDict(UserDict[str, DataUser[Any, Any]], PersistentStateMixin):
             user.load_state(path / name)
 
 
-class DataCollectorsDict(UserDict[str, DataCollector[Any]]):
+class DataCollectorsDict(UserDict[str, DataCollector[Any, Any]]):
     """A dictionary for managing exclusive access to data collectors.
 
     Manages exclusive access to data collectors to ensure each collector
@@ -115,7 +115,7 @@ class DataCollectorsDict(UserDict[str, DataCollector[Any]]):
         super().__init__(*args, **kwds)
         self._acquired_collectors: set[str] = set()
 
-    def acquire(self, collector_name: str) -> DataCollector[Any]:
+    def acquire(self, collector_name: str) -> DataCollector[Any, Any]:
         """Acquires a data collector for exclusive use within a step.
 
         Args:

--- a/src/pamiq_core/data/impls/random_replacement_buffer.py
+++ b/src/pamiq_core/data/impls/random_replacement_buffer.py
@@ -1,14 +1,14 @@
 import math
 import pickle
 import random
-from collections.abc import Iterable, Mapping
+from collections.abc import Iterable
 from pathlib import Path
 from typing import override
 
 from ..buffer import DataBuffer, StepData
 
 
-class RandomReplacementBuffer[T](DataBuffer[T]):
+class RandomReplacementBuffer[T](DataBuffer[T, dict[str, list[T]]]):
     """Buffer implementation that randomly replaces elements when full.
 
     This buffer keeps track of collected data and, when full, randomly
@@ -128,7 +128,7 @@ class RandomReplacementBuffer[T](DataBuffer[T]):
             self._current_size += 1
 
     @override
-    def get_data(self) -> Mapping[str, list[T]]:
+    def get_data(self) -> dict[str, list[T]]:
         """Retrieve all stored data from the buffer.
 
         Returns:

--- a/src/pamiq_core/data/impls/sequential_buffer.py
+++ b/src/pamiq_core/data/impls/sequential_buffer.py
@@ -7,7 +7,7 @@ from typing import override
 from ..buffer import DataBuffer, StepData
 
 
-class SequentialBuffer[T](DataBuffer[T]):
+class SequentialBuffer[T](DataBuffer[T, dict[str, list[T]]]):
     """Implementation of DataBuffer that maintains data in sequential order.
 
     This buffer stores collected data points in ordered queues,

--- a/src/pamiq_core/data/interface.py
+++ b/src/pamiq_core/data/interface.py
@@ -3,7 +3,7 @@ from collections import deque
 from collections.abc import Iterable
 from pathlib import Path
 from threading import RLock
-from typing import Any, override
+from typing import override
 
 from pamiq_core import time
 from pamiq_core.state_persistence import PersistentStateMixin
@@ -169,7 +169,7 @@ class DataUser[T, R](PersistentStateMixin):
         return len(self._buffer)
 
 
-class DataCollector[T]:
+class DataCollector[T, R]:
     """A thread-safe collector for buffered data.
 
     This class provides concurrent data collection capabilities with
@@ -181,7 +181,7 @@ class DataCollector[T]:
         R: The return type of the associated buffer's get_data() method.
     """
 
-    def __init__(self, user: DataUser[T, Any]) -> None:
+    def __init__(self, user: DataUser[T, R]) -> None:
         """Initialize DataCollector with a specified DataUser.
 
         Args:

--- a/src/pamiq_core/data/interface.py
+++ b/src/pamiq_core/data/interface.py
@@ -3,12 +3,12 @@ from collections import deque
 from collections.abc import Iterable
 from pathlib import Path
 from threading import RLock
-from typing import override
+from typing import Any, override
 
 from pamiq_core import time
 from pamiq_core.state_persistence import PersistentStateMixin
 
-from .buffer import BufferData, DataBuffer, StepData
+from .buffer import DataBuffer, StepData
 
 
 class TimestampingQueuesDict[T]:
@@ -65,16 +65,20 @@ class TimestampingQueuesDict[T]:
         return len(self._timestamps)
 
 
-class DataUser[T](PersistentStateMixin):
+class DataUser[T, R](PersistentStateMixin):
     """A class that manages data buffering and timestamps for collected data.
 
     This class acts as a user of data buffers, handling the collection,
     storage, and retrieval of data along with their timestamps. It works
     in conjunction with a DataCollector to manage concurrent data
     collection.
+
+    Type Parameters:
+        T: The type of data stored in each step.
+        R: The return type of the buffer's get_data() method.
     """
 
-    def __init__(self, buffer: DataBuffer[T]) -> None:
+    def __init__(self, buffer: DataBuffer[T, R]) -> None:
         """Initialize DataUser with a specified buffer.
 
         Args:
@@ -107,7 +111,7 @@ class DataUser[T](PersistentStateMixin):
             self._buffer.add(data)
             self._timestamps.append(t)
 
-    def get_data(self) -> BufferData[T]:
+    def get_data(self) -> R:
         """Retrieve data from the buffer.
 
         Returns:
@@ -171,9 +175,13 @@ class DataCollector[T]:
     This class provides concurrent data collection capabilities with
     thread safety, working in conjunction with DataUser to manage data
     collection and transfer.
+
+    Type Parameters:
+        T: The type of data stored in each step.
+        R: The return type of the associated buffer's get_data() method.
     """
 
-    def __init__(self, user: DataUser[T]) -> None:
+    def __init__(self, user: DataUser[T, Any]) -> None:
         """Initialize DataCollector with a specified DataUser.
 
         Args:

--- a/src/pamiq_core/interaction/agent.py
+++ b/src/pamiq_core/interaction/agent.py
@@ -116,7 +116,7 @@ class Agent[ObsType, ActType](
         """
         return self._inference_models[name]
 
-    def get_data_collector(self, name: str) -> DataCollector[Any]:
+    def get_data_collector(self, name: str) -> DataCollector[Any, Any]:
         """Acquires a data collector by name for exclusive use.
 
         This method acquires a data collector for exclusive use within

--- a/src/pamiq_core/launcher.py
+++ b/src/pamiq_core/launcher.py
@@ -60,7 +60,7 @@ class LaunchConfig:
 def launch(
     interaction: Interaction[Any, Any],
     models: Mapping[str, TrainingModel[Any]],
-    data: Mapping[str, DataBuffer[Any]],
+    data: Mapping[str, DataBuffer[Any, Any]],
     trainers: Mapping[str, Trainer],
     config: Mapping[str, Any] | LaunchConfig | None = None,
 ) -> None:

--- a/src/pamiq_core/testing.py
+++ b/src/pamiq_core/testing.py
@@ -32,7 +32,7 @@ class ConnectedComponents(NamedTuple):
 def connect_components(
     agent: Agent[Any, Any] | None = None,
     trainers: Trainer | Mapping[str, Trainer] | None = None,
-    buffers: Mapping[str, DataBuffer[Any]] | None = None,
+    buffers: Mapping[str, DataBuffer[Any, Any]] | None = None,
     models: Mapping[str, TrainingModel[Any]] | None = None,
 ) -> ConnectedComponents:
     """Connect PAMIQ Core components for testing or development.

--- a/src/pamiq_core/trainer/base.py
+++ b/src/pamiq_core/trainer/base.py
@@ -84,7 +84,7 @@ class Trainer(ABC, PersistentStateMixin, ThreadEventMixin):
         self._retrieved_model_names.add(name)
         return model
 
-    def get_data_user(self, name: str) -> DataUser[Any]:
+    def get_data_user(self, name: str) -> DataUser[Any, Any]:
         """Retrieves the data user."""
         return self._data_users[name]
 

--- a/src/pamiq_core/typing/__init__.py
+++ b/src/pamiq_core/typing/__init__.py
@@ -1,0 +1,6 @@
+from .data import DataCollectorType, DataUserType
+
+__all__ = [
+    "DataCollectorType",
+    "DataUserType",
+]

--- a/src/pamiq_core/typing/data.py
+++ b/src/pamiq_core/typing/data.py
@@ -2,5 +2,8 @@ from typing import Any
 
 from pamiq_core.data import DataCollector, DataUser
 
+# For Agent.get_data_collector
 type DataUserType[R] = DataUser[Any, R]
+
+# For Trainer.get_data_user
 type DataCollectorType[T] = DataCollector[T, Any]

--- a/src/pamiq_core/typing/data.py
+++ b/src/pamiq_core/typing/data.py
@@ -1,0 +1,6 @@
+from typing import Any
+
+from pamiq_core.data import DataCollector, DataUser
+
+type DataUserType[R] = DataUser[Any, R]
+type DataCollectorType[T] = DataCollector[T, Any]

--- a/tests/pamiq_core/data/helpers.py
+++ b/tests/pamiq_core/data/helpers.py
@@ -1,42 +1,6 @@
-from collections import deque
-from collections.abc import Iterable
-from typing import Any, override
+from typing import override
 
-from pamiq_core.data.buffer import BufferData, DataBuffer, StepData
-
-
-class DataBufferImpl(DataBuffer):
-    """Reference implementation of DataBuffer using deque.
-
-    This implementation is closer to production usage and is used for
-    testing the DataBuffer interface itself.
-    """
-
-    def __init__(self, collecting_data_names: Iterable[str], max_size: int) -> None:
-        super().__init__(collecting_data_names, max_size)
-        self._buffer: dict[str, deque[Any]] = {
-            name: deque(maxlen=max_size) for name in collecting_data_names
-        }
-
-        self._current_size = 0
-
-    @override
-    def add(self, step_data: StepData) -> None:
-        for name in self._collecting_data_names:
-            if name not in step_data:
-                raise KeyError(f"Required data '{name}' not found in step_data")
-            self._buffer[name].append(step_data[name])
-
-        if self._current_size < self.max_size:
-            self._current_size += 1
-
-    @override
-    def get_data(self) -> BufferData:
-        return self._buffer.copy()
-
-    @override
-    def __len__(self) -> int:
-        return self._current_size
+from pamiq_core.data.buffer import DataBuffer, StepData
 
 
 class MockDataBuffer(DataBuffer):
@@ -56,7 +20,7 @@ class MockDataBuffer(DataBuffer):
             self.data.append(step_data)
 
     @override
-    def get_data(self) -> BufferData:
+    def get_data(self):
         return {
             name: [d[name] for d in self.data] for name in self._collecting_data_names
         }

--- a/tests/pamiq_core/data/test_buffer.py
+++ b/tests/pamiq_core/data/test_buffer.py
@@ -1,9 +1,45 @@
+from collections import deque
+from collections.abc import Iterable
+from typing import Any, override
+
 import pytest
 
-from pamiq_core.data.buffer import DataBuffer
+from pamiq_core.data.buffer import DataBuffer, StepData
 from pamiq_core.state_persistence import PersistentStateMixin
 
-from .helpers import DataBufferImpl
+
+class DataBufferImpl(DataBuffer):
+    """Reference implementation of DataBuffer using deque.
+
+    This implementation is closer to production usage and is used for
+    testing the DataBuffer interface itself.
+    """
+
+    def __init__(self, collecting_data_names: Iterable[str], max_size: int) -> None:
+        super().__init__(collecting_data_names, max_size)
+        self._buffer: dict[str, deque[Any]] = {
+            name: deque(maxlen=max_size) for name in collecting_data_names
+        }
+
+        self._current_size = 0
+
+    @override
+    def add(self, step_data: StepData) -> None:
+        for name in self._collecting_data_names:
+            if name not in step_data:
+                raise KeyError(f"Required data '{name}' not found in step_data")
+            self._buffer[name].append(step_data[name])
+
+        if self._current_size < self.max_size:
+            self._current_size += 1
+
+    @override
+    def get_data(self) -> dict[str, deque[Any]]:
+        return self._buffer.copy()
+
+    @override
+    def __len__(self) -> int:
+        return self._current_size
 
 
 class TestDataBuffer:

--- a/tests/pamiq_core/data/test_interface.py
+++ b/tests/pamiq_core/data/test_interface.py
@@ -168,7 +168,7 @@ class TestDataUserAndCollector:
 
     def test_save_and_load_state(
         self,
-        data_user: DataUser[MockDataBuffer],
+        data_user: DataUser,
         mocker,
         buffer: MockDataBuffer,
         tmp_path: Path,


### PR DESCRIPTION
# Pull Request

## 内容

`get_data` メソッドの戻り値の型を指定可能にしました。これにより、自由にDataBufferがデータを保存し、データを加工して返すことができるようになり、柔軟性が向上します。

ただ、型パラメータが増えたため、破壊的変更となります。

DataCollectorやDataUserを型アノテーションとして使う際に、AgentやTrainerだと冗長になってしまう（Agentは入力データ型だけにフォーカスするのに対して、Trainerは取得する際のデータ型にフォーカスしたい）ため、新たに`typing`モジュールを実装し、簡便にするためのものを用意しました。

実はこの次に`StepData`を削除する破壊的な変更を行うため、ドキュメントへの追記は一旦抑えています。

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [ ] なし
- [x] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
