### PR TITLE
StepDataを削除し、Dataモジュールを大幅にリファクタリング

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # Out project
+.claude
 .ruff_cache
 
 # Byte-compiled / optimized / DLL files

--- a/docs/api/data.md
+++ b/docs/api/data.md
@@ -3,3 +3,5 @@
 ::: pamiq_core.data.DataUser
 ::: pamiq_core.data.impls.SequentialBuffer
 ::: pamiq_core.data.impls.RandomReplacementBuffer
+::: pamiq_core.data.impls.DictSequentialBuffer
+::: pamiq_core.data.impls.DictRandomReplacementBuffer

--- a/docs/user-guide/data.md
+++ b/docs/user-guide/data.md
@@ -296,6 +296,15 @@ collector.collect({"state": s, "action": a, "reward": r})
 
 State files now use `.pkl` extension automatically - no code changes needed.
 
+## Type Helpers
+
+PAMIQ-Core provides convenient type aliases in `pamiq_core.typing.data` for working with data collectors and users:
+
+- `DataCollectorType[T]`: Type alias for `DataCollector[T, Any]` - useful when you only care about the input type
+- `DataUserType[R]`: Type alias for `DataUser[Any, R]` - useful when you only care about the return type
+
+These help simplify type annotations in your agents and trainers.
+
 ______________________________________________________________________
 
 ## API Reference

--- a/docs/user-guide/data.md
+++ b/docs/user-guide/data.md
@@ -296,15 +296,6 @@ collector.collect({"state": s, "action": a, "reward": r})
 
 State files now use `.pkl` extension automatically - no code changes needed.
 
-## Type Helpers
-
-PAMIQ-Core provides convenient type aliases in `pamiq_core.typing.data` for working with data collectors and users:
-
-- `DataCollectorType[T]`: Type alias for `DataCollector[T, Any]` - useful when you only care about the input type
-- `DataUserType[R]`: Type alias for `DataUser[Any, R]` - useful when you only care about the return type
-
-These help simplify type annotations in your agents and trainers.
-
 ______________________________________________________________________
 
 ## API Reference

--- a/docs/user-guide/data.md
+++ b/docs/user-guide/data.md
@@ -181,7 +181,7 @@ The `SequentialBuffer` stores data in sequence and discards the oldest data when
 ```python
 from pamiq_core.data.impls import SequentialBuffer
 
-# Create a buffer for experience tuples with max size 1000
+# Create a buffer for experiences with max size 1000
 buffer = SequentialBuffer[tuple[list[float], int, float]](max_size=1000)
 
 # Add data
@@ -221,7 +221,7 @@ The `RandomReplacementBuffer` fills up to its maximum size and then randomly rep
 from pamiq_core.data.impls import RandomReplacementBuffer
 
 # Create a buffer with 80% replacement probability
-buffer = RandomReplacementBuffer[tuple[list[float], int, float]](
+buffer = RandomReplacementBuffer[int](
     max_size=1000,
     replace_probability=0.8
 )

--- a/docs/user-guide/interaction.md
+++ b/docs/user-guide/interaction.md
@@ -33,6 +33,23 @@ class MyAgent(Agent[list[float], int]):
             return 0
 ```
 
+### Type Annotations
+
+For cleaner type hints when working with data collectors, you can use the type helpers from `pamiq_core.typing.data`:
+
+```python
+from pamiq_core import Agent
+from pamiq_core.typing.data import DataCollectorType
+from typing import override
+
+class MyAgent(Agent[float, int]):
+    experience_collector: DataCollectorType[tuple[float, int, float]]
+
+    @override
+    def on_data_collectors_attached(self) -> None:
+        self.experience_collector = self.get_data_collector("experience")
+```
+
 ### Composite Agents
 
 Agents can contain child agents that share the parent's inference models and data collectors. This is useful for building hierarchical decision-making systems or dividing complex agent logic into modular components:

--- a/docs/user-guide/interaction.md
+++ b/docs/user-guide/interaction.md
@@ -33,23 +33,6 @@ class MyAgent(Agent[list[float], int]):
             return 0
 ```
 
-### Type Annotations
-
-For cleaner type hints when working with data collectors, you can use the type helpers from `pamiq_core.typing.data`:
-
-```python
-from pamiq_core import Agent
-from pamiq_core.typing.data import DataCollectorType
-from typing import override
-
-class MyAgent(Agent[float, int]):
-    experience_collector: DataCollectorType[tuple[float, int, float]]
-
-    @override
-    def on_data_collectors_attached(self) -> None:
-        self.experience_collector = self.get_data_collector("experience")
-```
-
 ### Composite Agents
 
 Agents can contain child agents that share the parent's inference models and data collectors. This is useful for building hierarchical decision-making systems or dividing complex agent logic into modular components:

--- a/docs/user-guide/trainer.md
+++ b/docs/user-guide/trainer.md
@@ -47,23 +47,6 @@ class MyTrainer(Trainer):
         # Model parameters will be automatically synchronized after training
 ```
 
-### Type Annotations
-
-For cleaner type hints when working with data users, you can use the type helpers from `pamiq_core.typing.data`:
-
-```python
-from pamiq_core import Trainer
-from pamiq_core.typing.data import DataUserType
-from typing import override
-
-class MyTrainer(Trainer):
-    experience_data: DataUserType[list[tuple[float, int, float]]]
-
-    @override
-    def on_data_users_attached(self) -> None:
-        self.experience_data = self.get_data_user("experience")
-```
-
 ### Training Conditions
 
 PAMIQ-Core trainers can be configured with conditions to determine when training should occur:

--- a/docs/user-guide/trainer.md
+++ b/docs/user-guide/trainer.md
@@ -47,6 +47,23 @@ class MyTrainer(Trainer):
         # Model parameters will be automatically synchronized after training
 ```
 
+### Type Annotations
+
+For cleaner type hints when working with data users, you can use the type helpers from `pamiq_core.typing.data`:
+
+```python
+from pamiq_core import Trainer
+from pamiq_core.typing.data import DataUserType
+from typing import override
+
+class MyTrainer(Trainer):
+    experience_data: DataUserType[list[tuple[float, int, float]]]
+
+    @override
+    def on_data_users_attached(self) -> None:
+        self.experience_data = self.get_data_user("experience")
+```
+
 ### Training Conditions
 
 PAMIQ-Core trainers can be configured with conditions to determine when training should occur:

--- a/samples/vae-torch/agent.py
+++ b/samples/vae-torch/agent.py
@@ -51,7 +51,6 @@ class EncodingAgent(Agent[Tensor, Tensor]):
         self.data_collector.collect(
             {"data": observation.cpu()}
         )  # explanation of this line:
-        # The data_collector supports multiple named data stacks.
-        # Here, we add the current observation to the stack named "data".
+        # Here, we add the current observation to the stack.
         # The data stack is used in the training process in `trainer.py`.
         return self.encoder(observation)

--- a/samples/vae-torch/main.py
+++ b/samples/vae-torch/main.py
@@ -44,7 +44,7 @@ def main():
         ),
     }
 
-    data = {"observation": RandomReplacementBuffer(["data"], max_size=1024)}
+    data = {"observation": RandomReplacementBuffer(max_size=1024)}
     trainers = {"vae": VAETrainer(max_epochs=3, batch_size=32)}
 
     launch(

--- a/samples/vae-torch/trainer.py
+++ b/samples/vae-torch/trainer.py
@@ -92,7 +92,7 @@ class VAETrainer(TorchTrainer):
         computation, and backpropagation. It logs the training metrics
         to TensorBoard.
         """
-        data = self.data_user.get_data()["data"]
+        data = self.data_user.get_data()
         dataset = TensorDataset(torch.stack(list(data)))
         dataloader = DataLoader(dataset, batch_size=self.batch_size, shuffle=True)
 

--- a/samples/vae-torch/uv.lock
+++ b/samples/vae-torch/uv.lock
@@ -1,14 +1,13 @@
 version = 1
-revision = 2
 requires-python = ">=3.12"
 
 [[package]]
 name = "absl-py"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/03/15/18693af986560a5c3cc0b84a8046b536ffb2cdb536e03cce897f2759e284/absl_py-2.3.0.tar.gz", hash = "sha256:d96fda5c884f1b22178852f30ffa85766d50b99e00775ea626c23304f582fc4f", size = 116400, upload-time = "2025-05-27T09:15:50.143Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/15/18693af986560a5c3cc0b84a8046b536ffb2cdb536e03cce897f2759e284/absl_py-2.3.0.tar.gz", hash = "sha256:d96fda5c884f1b22178852f30ffa85766d50b99e00775ea626c23304f582fc4f", size = 116400 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/04/9d75e1d3bb4ab8ec67ff10919476ccdee06c098bcfcf3a352da5f985171d/absl_py-2.3.0-py3-none-any.whl", hash = "sha256:9824a48b654a306168f63e0d97714665f8490b8d89ec7bf2efc24bf67cf579b3", size = 135657, upload-time = "2025-05-27T09:15:48.742Z" },
+    { url = "https://files.pythonhosted.org/packages/87/04/9d75e1d3bb4ab8ec67ff10919476ccdee06c098bcfcf3a352da5f985171d/absl_py-2.3.0-py3-none-any.whl", hash = "sha256:9824a48b654a306168f63e0d97714665f8490b8d89ec7bf2efc24bf67cf579b3", size = 135657 },
 ]
 
 [[package]]
@@ -20,18 +19,18 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949, upload-time = "2025-03-17T00:02:54.77Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916, upload-time = "2025-03-17T00:02:52.713Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916 },
 ]
 
 [[package]]
 name = "certifi"
 version = "2025.4.26"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705, upload-time = "2025-04-26T02:12:29.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/9e/c05b3920a3b7d20d3d3310465f50348e5b3694f4f88c6daf736eef3024c4/certifi-2025.4.26.tar.gz", hash = "sha256:0a816057ea3cdefcef70270d2c515e4506bbc954f417fa5ade2021213bb8f0c6", size = 160705 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618, upload-time = "2025-04-26T02:12:27.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/7e/3db2bd1b1f9e95f7cddca6d6e75e2f2bd9f51b1246e546d88addca0106bd/certifi-2025.4.26-py3-none-any.whl", hash = "sha256:30350364dfe371162649852c63336a15c70c6510c2ad5015b21c2345311805f3", size = 159618 },
 ]
 
 [[package]]
@@ -41,73 +40,73 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
 ]
 
 [[package]]
 name = "filelock"
 version = "3.18.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075, upload-time = "2025-03-14T07:11:40.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/10/c23352565a6544bdc5353e0b15fc1c563352101f30e24bf500207a54df9a/filelock-3.18.0.tar.gz", hash = "sha256:adbc88eabb99d2fec8c9c1b229b171f18afa655400173ddc653d5d01501fb9f2", size = 18075 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215, upload-time = "2025-03-14T07:11:39.145Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/36/2a115987e2d8c300a974597416d9de88f2444426de9571f4b59b2cca3acc/filelock-3.18.0-py3-none-any.whl", hash = "sha256:c401f4f8377c4464e6db25fff06205fd89bdd83b65eb0488ed1b160f780e21de", size = 16215 },
 ]
 
 [[package]]
 name = "fsspec"
 version = "2025.3.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/45/d8/8425e6ba5fcec61a1d16e41b1b71d2bf9344f1fe48012c2b48b9620feae5/fsspec-2025.3.2.tar.gz", hash = "sha256:e52c77ef398680bbd6a98c0e628fbc469491282981209907bbc8aea76a04fdc6", size = 299281, upload-time = "2025-03-31T15:27:08.524Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/d8/8425e6ba5fcec61a1d16e41b1b71d2bf9344f1fe48012c2b48b9620feae5/fsspec-2025.3.2.tar.gz", hash = "sha256:e52c77ef398680bbd6a98c0e628fbc469491282981209907bbc8aea76a04fdc6", size = 299281 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/4b/e0cfc1a6f17e990f3e64b7d941ddc4acdc7b19d6edd51abf495f32b1a9e4/fsspec-2025.3.2-py3-none-any.whl", hash = "sha256:2daf8dc3d1dfa65b6aa37748d112773a7a08416f6c70d96b264c96476ecaf711", size = 194435, upload-time = "2025-03-31T15:27:07.028Z" },
+    { url = "https://files.pythonhosted.org/packages/44/4b/e0cfc1a6f17e990f3e64b7d941ddc4acdc7b19d6edd51abf495f32b1a9e4/fsspec-2025.3.2-py3-none-any.whl", hash = "sha256:2daf8dc3d1dfa65b6aa37748d112773a7a08416f6c70d96b264c96476ecaf711", size = 194435 },
 ]
 
 [[package]]
 name = "grpcio"
 version = "1.71.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/95/aa11fc09a85d91fbc7dd405dcb2a1e0256989d67bf89fa65ae24b3ba105a/grpcio-1.71.0.tar.gz", hash = "sha256:2b85f7820475ad3edec209d3d89a7909ada16caab05d3f2e08a7e8ae3200a55c", size = 12549828, upload-time = "2025-03-10T19:28:49.203Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/95/aa11fc09a85d91fbc7dd405dcb2a1e0256989d67bf89fa65ae24b3ba105a/grpcio-1.71.0.tar.gz", hash = "sha256:2b85f7820475ad3edec209d3d89a7909ada16caab05d3f2e08a7e8ae3200a55c", size = 12549828 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/83/bd4b6a9ba07825bd19c711d8b25874cd5de72c2a3fbf635c3c344ae65bd2/grpcio-1.71.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:0ff35c8d807c1c7531d3002be03221ff9ae15712b53ab46e2a0b4bb271f38537", size = 5184101, upload-time = "2025-03-10T19:24:54.11Z" },
-    { url = "https://files.pythonhosted.org/packages/31/ea/2e0d90c0853568bf714693447f5c73272ea95ee8dad107807fde740e595d/grpcio-1.71.0-cp312-cp312-macosx_10_14_universal2.whl", hash = "sha256:b78a99cd1ece4be92ab7c07765a0b038194ded2e0a26fd654591ee136088d8d7", size = 11310927, upload-time = "2025-03-10T19:24:56.1Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/bc/07a3fd8af80467390af491d7dc66882db43884128cdb3cc8524915e0023c/grpcio-1.71.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:dc1a1231ed23caac1de9f943d031f1bc38d0f69d2a3b243ea0d664fc1fbd7fec", size = 5654280, upload-time = "2025-03-10T19:24:58.55Z" },
-    { url = "https://files.pythonhosted.org/packages/16/af/21f22ea3eed3d0538b6ef7889fce1878a8ba4164497f9e07385733391e2b/grpcio-1.71.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6beeea5566092c5e3c4896c6d1d307fb46b1d4bdf3e70c8340b190a69198594", size = 6312051, upload-time = "2025-03-10T19:25:00.682Z" },
-    { url = "https://files.pythonhosted.org/packages/49/9d/e12ddc726dc8bd1aa6cba67c85ce42a12ba5b9dd75d5042214a59ccf28ce/grpcio-1.71.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5170929109450a2c031cfe87d6716f2fae39695ad5335d9106ae88cc32dc84c", size = 5910666, upload-time = "2025-03-10T19:25:03.01Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/e9/38713d6d67aedef738b815763c25f092e0454dc58e77b1d2a51c9d5b3325/grpcio-1.71.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5b08d03ace7aca7b2fadd4baf291139b4a5f058805a8327bfe9aece7253b6d67", size = 6012019, upload-time = "2025-03-10T19:25:05.174Z" },
-    { url = "https://files.pythonhosted.org/packages/80/da/4813cd7adbae6467724fa46c952d7aeac5e82e550b1c62ed2aeb78d444ae/grpcio-1.71.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:f903017db76bf9cc2b2d8bdd37bf04b505bbccad6be8a81e1542206875d0e9db", size = 6637043, upload-time = "2025-03-10T19:25:06.987Z" },
-    { url = "https://files.pythonhosted.org/packages/52/ca/c0d767082e39dccb7985c73ab4cf1d23ce8613387149e9978c70c3bf3b07/grpcio-1.71.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:469f42a0b410883185eab4689060a20488a1a0a00f8bbb3cbc1061197b4c5a79", size = 6186143, upload-time = "2025-03-10T19:25:08.877Z" },
-    { url = "https://files.pythonhosted.org/packages/00/61/7b2c8ec13303f8fe36832c13d91ad4d4ba57204b1c723ada709c346b2271/grpcio-1.71.0-cp312-cp312-win32.whl", hash = "sha256:ad9f30838550695b5eb302add33f21f7301b882937460dd24f24b3cc5a95067a", size = 3604083, upload-time = "2025-03-10T19:25:10.736Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/7c/1e429c5fb26122055d10ff9a1d754790fb067d83c633ff69eddcf8e3614b/grpcio-1.71.0-cp312-cp312-win_amd64.whl", hash = "sha256:652350609332de6dac4ece254e5d7e1ff834e203d6afb769601f286886f6f3a8", size = 4272191, upload-time = "2025-03-10T19:25:13.12Z" },
-    { url = "https://files.pythonhosted.org/packages/04/dd/b00cbb45400d06b26126dcfdbdb34bb6c4f28c3ebbd7aea8228679103ef6/grpcio-1.71.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:cebc1b34ba40a312ab480ccdb396ff3c529377a2fce72c45a741f7215bfe8379", size = 5184138, upload-time = "2025-03-10T19:25:15.101Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/0a/4651215983d590ef53aac40ba0e29dda941a02b097892c44fa3357e706e5/grpcio-1.71.0-cp313-cp313-macosx_10_14_universal2.whl", hash = "sha256:85da336e3649a3d2171e82f696b5cad2c6231fdd5bad52616476235681bee5b3", size = 11310747, upload-time = "2025-03-10T19:25:17.201Z" },
-    { url = "https://files.pythonhosted.org/packages/57/a3/149615b247f321e13f60aa512d3509d4215173bdb982c9098d78484de216/grpcio-1.71.0-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:f9a412f55bb6e8f3bb000e020dbc1e709627dcb3a56f6431fa7076b4c1aab0db", size = 5653991, upload-time = "2025-03-10T19:25:20.39Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/56/29432a3e8d951b5e4e520a40cd93bebaa824a14033ea8e65b0ece1da6167/grpcio-1.71.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47be9584729534660416f6d2a3108aaeac1122f6b5bdbf9fd823e11fe6fbaa29", size = 6312781, upload-time = "2025-03-10T19:25:22.823Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/f8/286e81a62964ceb6ac10b10925261d4871a762d2a763fbf354115f9afc98/grpcio-1.71.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c9c80ac6091c916db81131d50926a93ab162a7e97e4428ffc186b6e80d6dda4", size = 5910479, upload-time = "2025-03-10T19:25:24.828Z" },
-    { url = "https://files.pythonhosted.org/packages/35/67/d1febb49ec0f599b9e6d4d0d44c2d4afdbed9c3e80deb7587ec788fcf252/grpcio-1.71.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:789d5e2a3a15419374b7b45cd680b1e83bbc1e52b9086e49308e2c0b5bbae6e3", size = 6013262, upload-time = "2025-03-10T19:25:26.987Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/04/f9ceda11755f0104a075ad7163fc0d96e2e3a9fe25ef38adfc74c5790daf/grpcio-1.71.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:1be857615e26a86d7363e8a163fade914595c81fec962b3d514a4b1e8760467b", size = 6643356, upload-time = "2025-03-10T19:25:29.606Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/ce/236dbc3dc77cf9a9242adcf1f62538734ad64727fabf39e1346ad4bd5c75/grpcio-1.71.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a76d39b5fafd79ed604c4be0a869ec3581a172a707e2a8d7a4858cb05a5a7637", size = 6186564, upload-time = "2025-03-10T19:25:31.537Z" },
-    { url = "https://files.pythonhosted.org/packages/10/fd/b3348fce9dd4280e221f513dd54024e765b21c348bc475516672da4218e9/grpcio-1.71.0-cp313-cp313-win32.whl", hash = "sha256:74258dce215cb1995083daa17b379a1a5a87d275387b7ffe137f1d5131e2cfbb", size = 3601890, upload-time = "2025-03-10T19:25:33.421Z" },
-    { url = "https://files.pythonhosted.org/packages/be/f8/db5d5f3fc7e296166286c2a397836b8b042f7ad1e11028d82b061701f0f7/grpcio-1.71.0-cp313-cp313-win_amd64.whl", hash = "sha256:22c3bc8d488c039a199f7a003a38cb7635db6656fa96437a8accde8322ce2366", size = 4273308, upload-time = "2025-03-10T19:25:35.79Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/83/bd4b6a9ba07825bd19c711d8b25874cd5de72c2a3fbf635c3c344ae65bd2/grpcio-1.71.0-cp312-cp312-linux_armv7l.whl", hash = "sha256:0ff35c8d807c1c7531d3002be03221ff9ae15712b53ab46e2a0b4bb271f38537", size = 5184101 },
+    { url = "https://files.pythonhosted.org/packages/31/ea/2e0d90c0853568bf714693447f5c73272ea95ee8dad107807fde740e595d/grpcio-1.71.0-cp312-cp312-macosx_10_14_universal2.whl", hash = "sha256:b78a99cd1ece4be92ab7c07765a0b038194ded2e0a26fd654591ee136088d8d7", size = 11310927 },
+    { url = "https://files.pythonhosted.org/packages/ac/bc/07a3fd8af80467390af491d7dc66882db43884128cdb3cc8524915e0023c/grpcio-1.71.0-cp312-cp312-manylinux_2_17_aarch64.whl", hash = "sha256:dc1a1231ed23caac1de9f943d031f1bc38d0f69d2a3b243ea0d664fc1fbd7fec", size = 5654280 },
+    { url = "https://files.pythonhosted.org/packages/16/af/21f22ea3eed3d0538b6ef7889fce1878a8ba4164497f9e07385733391e2b/grpcio-1.71.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6beeea5566092c5e3c4896c6d1d307fb46b1d4bdf3e70c8340b190a69198594", size = 6312051 },
+    { url = "https://files.pythonhosted.org/packages/49/9d/e12ddc726dc8bd1aa6cba67c85ce42a12ba5b9dd75d5042214a59ccf28ce/grpcio-1.71.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d5170929109450a2c031cfe87d6716f2fae39695ad5335d9106ae88cc32dc84c", size = 5910666 },
+    { url = "https://files.pythonhosted.org/packages/d9/e9/38713d6d67aedef738b815763c25f092e0454dc58e77b1d2a51c9d5b3325/grpcio-1.71.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:5b08d03ace7aca7b2fadd4baf291139b4a5f058805a8327bfe9aece7253b6d67", size = 6012019 },
+    { url = "https://files.pythonhosted.org/packages/80/da/4813cd7adbae6467724fa46c952d7aeac5e82e550b1c62ed2aeb78d444ae/grpcio-1.71.0-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:f903017db76bf9cc2b2d8bdd37bf04b505bbccad6be8a81e1542206875d0e9db", size = 6637043 },
+    { url = "https://files.pythonhosted.org/packages/52/ca/c0d767082e39dccb7985c73ab4cf1d23ce8613387149e9978c70c3bf3b07/grpcio-1.71.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:469f42a0b410883185eab4689060a20488a1a0a00f8bbb3cbc1061197b4c5a79", size = 6186143 },
+    { url = "https://files.pythonhosted.org/packages/00/61/7b2c8ec13303f8fe36832c13d91ad4d4ba57204b1c723ada709c346b2271/grpcio-1.71.0-cp312-cp312-win32.whl", hash = "sha256:ad9f30838550695b5eb302add33f21f7301b882937460dd24f24b3cc5a95067a", size = 3604083 },
+    { url = "https://files.pythonhosted.org/packages/fd/7c/1e429c5fb26122055d10ff9a1d754790fb067d83c633ff69eddcf8e3614b/grpcio-1.71.0-cp312-cp312-win_amd64.whl", hash = "sha256:652350609332de6dac4ece254e5d7e1ff834e203d6afb769601f286886f6f3a8", size = 4272191 },
+    { url = "https://files.pythonhosted.org/packages/04/dd/b00cbb45400d06b26126dcfdbdb34bb6c4f28c3ebbd7aea8228679103ef6/grpcio-1.71.0-cp313-cp313-linux_armv7l.whl", hash = "sha256:cebc1b34ba40a312ab480ccdb396ff3c529377a2fce72c45a741f7215bfe8379", size = 5184138 },
+    { url = "https://files.pythonhosted.org/packages/ed/0a/4651215983d590ef53aac40ba0e29dda941a02b097892c44fa3357e706e5/grpcio-1.71.0-cp313-cp313-macosx_10_14_universal2.whl", hash = "sha256:85da336e3649a3d2171e82f696b5cad2c6231fdd5bad52616476235681bee5b3", size = 11310747 },
+    { url = "https://files.pythonhosted.org/packages/57/a3/149615b247f321e13f60aa512d3509d4215173bdb982c9098d78484de216/grpcio-1.71.0-cp313-cp313-manylinux_2_17_aarch64.whl", hash = "sha256:f9a412f55bb6e8f3bb000e020dbc1e709627dcb3a56f6431fa7076b4c1aab0db", size = 5653991 },
+    { url = "https://files.pythonhosted.org/packages/ca/56/29432a3e8d951b5e4e520a40cd93bebaa824a14033ea8e65b0ece1da6167/grpcio-1.71.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:47be9584729534660416f6d2a3108aaeac1122f6b5bdbf9fd823e11fe6fbaa29", size = 6312781 },
+    { url = "https://files.pythonhosted.org/packages/a3/f8/286e81a62964ceb6ac10b10925261d4871a762d2a763fbf354115f9afc98/grpcio-1.71.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7c9c80ac6091c916db81131d50926a93ab162a7e97e4428ffc186b6e80d6dda4", size = 5910479 },
+    { url = "https://files.pythonhosted.org/packages/35/67/d1febb49ec0f599b9e6d4d0d44c2d4afdbed9c3e80deb7587ec788fcf252/grpcio-1.71.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:789d5e2a3a15419374b7b45cd680b1e83bbc1e52b9086e49308e2c0b5bbae6e3", size = 6013262 },
+    { url = "https://files.pythonhosted.org/packages/a1/04/f9ceda11755f0104a075ad7163fc0d96e2e3a9fe25ef38adfc74c5790daf/grpcio-1.71.0-cp313-cp313-musllinux_1_1_i686.whl", hash = "sha256:1be857615e26a86d7363e8a163fade914595c81fec962b3d514a4b1e8760467b", size = 6643356 },
+    { url = "https://files.pythonhosted.org/packages/fb/ce/236dbc3dc77cf9a9242adcf1f62538734ad64727fabf39e1346ad4bd5c75/grpcio-1.71.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a76d39b5fafd79ed604c4be0a869ec3581a172a707e2a8d7a4858cb05a5a7637", size = 6186564 },
+    { url = "https://files.pythonhosted.org/packages/10/fd/b3348fce9dd4280e221f513dd54024e765b21c348bc475516672da4218e9/grpcio-1.71.0-cp313-cp313-win32.whl", hash = "sha256:74258dce215cb1995083daa17b379a1a5a87d275387b7ffe137f1d5131e2cfbb", size = 3601890 },
+    { url = "https://files.pythonhosted.org/packages/be/f8/db5d5f3fc7e296166286c2a397836b8b042f7ad1e11028d82b061701f0f7/grpcio-1.71.0-cp313-cp313-win_amd64.whl", hash = "sha256:22c3bc8d488c039a199f7a003a38cb7635db6656fa96437a8accde8322ce2366", size = 4273308 },
 ]
 
 [[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
 ]
 
 [[package]]
@@ -118,9 +117,9 @@ dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
 ]
 
 [[package]]
@@ -133,18 +132,18 @@ dependencies = [
     { name = "httpcore" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
 ]
 
 [[package]]
@@ -154,112 +153,112 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899 },
 ]
 
 [[package]]
 name = "markdown"
 version = "3.8"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2f/15/222b423b0b88689c266d9eac4e61396fe2cc53464459d6a37618ac863b24/markdown-3.8.tar.gz", hash = "sha256:7df81e63f0df5c4b24b7d156eb81e4690595239b7d70937d0409f1b0de319c6f", size = 360906, upload-time = "2025-04-11T14:42:50.928Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/15/222b423b0b88689c266d9eac4e61396fe2cc53464459d6a37618ac863b24/markdown-3.8.tar.gz", hash = "sha256:7df81e63f0df5c4b24b7d156eb81e4690595239b7d70937d0409f1b0de319c6f", size = 360906 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/3f/afe76f8e2246ffbc867440cbcf90525264df0e658f8a5ca1f872b3f6192a/markdown-3.8-py3-none-any.whl", hash = "sha256:794a929b79c5af141ef5ab0f2f642d0f7b1872981250230e72682346f7cc90dc", size = 106210, upload-time = "2025-04-11T14:42:49.178Z" },
+    { url = "https://files.pythonhosted.org/packages/51/3f/afe76f8e2246ffbc867440cbcf90525264df0e658f8a5ca1f872b3f6192a/markdown-3.8-py3-none-any.whl", hash = "sha256:794a929b79c5af141ef5ab0f2f642d0f7b1872981250230e72682346f7cc90dc", size = 106210 },
 ]
 
 [[package]]
 name = "markupsafe"
 version = "3.0.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537, upload-time = "2024-10-18T15:21:54.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/97/5d42485e71dfc078108a86d6de8fa46db44a1a9295e89c5d6d4a06e23a62/markupsafe-3.0.2.tar.gz", hash = "sha256:ee55d3edf80167e48ea11a923c7386f4669df67d7994554387f84e7d8b0a2bf0", size = 20537 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274, upload-time = "2024-10-18T15:21:13.777Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348, upload-time = "2024-10-18T15:21:14.822Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149, upload-time = "2024-10-18T15:21:15.642Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118, upload-time = "2024-10-18T15:21:17.133Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993, upload-time = "2024-10-18T15:21:18.064Z" },
-    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178, upload-time = "2024-10-18T15:21:18.859Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319, upload-time = "2024-10-18T15:21:19.671Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352, upload-time = "2024-10-18T15:21:20.971Z" },
-    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097, upload-time = "2024-10-18T15:21:22.646Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601, upload-time = "2024-10-18T15:21:23.499Z" },
-    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274, upload-time = "2024-10-18T15:21:24.577Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352, upload-time = "2024-10-18T15:21:25.382Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122, upload-time = "2024-10-18T15:21:26.199Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085, upload-time = "2024-10-18T15:21:27.029Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978, upload-time = "2024-10-18T15:21:27.846Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208, upload-time = "2024-10-18T15:21:28.744Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357, upload-time = "2024-10-18T15:21:29.545Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344, upload-time = "2024-10-18T15:21:30.366Z" },
-    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101, upload-time = "2024-10-18T15:21:31.207Z" },
-    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603, upload-time = "2024-10-18T15:21:32.032Z" },
-    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510, upload-time = "2024-10-18T15:21:33.625Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486, upload-time = "2024-10-18T15:21:34.611Z" },
-    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480, upload-time = "2024-10-18T15:21:35.398Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914, upload-time = "2024-10-18T15:21:36.231Z" },
-    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796, upload-time = "2024-10-18T15:21:37.073Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473, upload-time = "2024-10-18T15:21:37.932Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114, upload-time = "2024-10-18T15:21:39.799Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098, upload-time = "2024-10-18T15:21:40.813Z" },
-    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208, upload-time = "2024-10-18T15:21:41.814Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739, upload-time = "2024-10-18T15:21:42.784Z" },
+    { url = "https://files.pythonhosted.org/packages/22/09/d1f21434c97fc42f09d290cbb6350d44eb12f09cc62c9476effdb33a18aa/MarkupSafe-3.0.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:9778bd8ab0a994ebf6f84c2b949e65736d5575320a17ae8984a77fab08db94cf", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/6b/b0/18f76bba336fa5aecf79d45dcd6c806c280ec44538b3c13671d49099fdd0/MarkupSafe-3.0.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:846ade7b71e3536c4e56b386c2a47adf5741d2d8b94ec9dc3e92e5e1ee1e2225", size = 12348 },
+    { url = "https://files.pythonhosted.org/packages/e0/25/dd5c0f6ac1311e9b40f4af06c78efde0f3b5cbf02502f8ef9501294c425b/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c99d261bd2d5f6b59325c92c73df481e05e57f19837bdca8413b9eac4bd8028", size = 24149 },
+    { url = "https://files.pythonhosted.org/packages/f3/f0/89e7aadfb3749d0f52234a0c8c7867877876e0a20b60e2188e9850794c17/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e17c96c14e19278594aa4841ec148115f9c7615a47382ecb6b82bd8fea3ab0c8", size = 23118 },
+    { url = "https://files.pythonhosted.org/packages/d5/da/f2eeb64c723f5e3777bc081da884b414671982008c47dcc1873d81f625b6/MarkupSafe-3.0.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:88416bd1e65dcea10bc7569faacb2c20ce071dd1f87539ca2ab364bf6231393c", size = 22993 },
+    { url = "https://files.pythonhosted.org/packages/da/0e/1f32af846df486dce7c227fe0f2398dc7e2e51d4a370508281f3c1c5cddc/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2181e67807fc2fa785d0592dc2d6206c019b9502410671cc905d132a92866557", size = 24178 },
+    { url = "https://files.pythonhosted.org/packages/c4/f6/bb3ca0532de8086cbff5f06d137064c8410d10779c4c127e0e47d17c0b71/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:52305740fe773d09cffb16f8ed0427942901f00adedac82ec8b67752f58a1b22", size = 23319 },
+    { url = "https://files.pythonhosted.org/packages/a2/82/8be4c96ffee03c5b4a034e60a31294daf481e12c7c43ab8e34a1453ee48b/MarkupSafe-3.0.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad10d3ded218f1039f11a75f8091880239651b52e9bb592ca27de44eed242a48", size = 23352 },
+    { url = "https://files.pythonhosted.org/packages/51/ae/97827349d3fcffee7e184bdf7f41cd6b88d9919c80f0263ba7acd1bbcb18/MarkupSafe-3.0.2-cp312-cp312-win32.whl", hash = "sha256:0f4ca02bea9a23221c0182836703cbf8930c5e9454bacce27e767509fa286a30", size = 15097 },
+    { url = "https://files.pythonhosted.org/packages/c1/80/a61f99dc3a936413c3ee4e1eecac96c0da5ed07ad56fd975f1a9da5bc630/MarkupSafe-3.0.2-cp312-cp312-win_amd64.whl", hash = "sha256:8e06879fc22a25ca47312fbe7c8264eb0b662f6db27cb2d3bbbc74b1df4b9b87", size = 15601 },
+    { url = "https://files.pythonhosted.org/packages/83/0e/67eb10a7ecc77a0c2bbe2b0235765b98d164d81600746914bebada795e97/MarkupSafe-3.0.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ba9527cdd4c926ed0760bc301f6728ef34d841f405abf9d4f959c478421e4efd", size = 14274 },
+    { url = "https://files.pythonhosted.org/packages/2b/6d/9409f3684d3335375d04e5f05744dfe7e9f120062c9857df4ab490a1031a/MarkupSafe-3.0.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f8b3d067f2e40fe93e1ccdd6b2e1d16c43140e76f02fb1319a05cf2b79d99430", size = 12352 },
+    { url = "https://files.pythonhosted.org/packages/d2/f5/6eadfcd3885ea85fe2a7c128315cc1bb7241e1987443d78c8fe712d03091/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:569511d3b58c8791ab4c2e1285575265991e6d8f8700c7be0e88f86cb0672094", size = 24122 },
+    { url = "https://files.pythonhosted.org/packages/0c/91/96cf928db8236f1bfab6ce15ad070dfdd02ed88261c2afafd4b43575e9e9/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:15ab75ef81add55874e7ab7055e9c397312385bd9ced94920f2802310c930396", size = 23085 },
+    { url = "https://files.pythonhosted.org/packages/c2/cf/c9d56af24d56ea04daae7ac0940232d31d5a8354f2b457c6d856b2057d69/MarkupSafe-3.0.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f3818cb119498c0678015754eba762e0d61e5b52d34c8b13d770f0719f7b1d79", size = 22978 },
+    { url = "https://files.pythonhosted.org/packages/2a/9f/8619835cd6a711d6272d62abb78c033bda638fdc54c4e7f4272cf1c0962b/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:cdb82a876c47801bb54a690c5ae105a46b392ac6099881cdfb9f6e95e4014c6a", size = 24208 },
+    { url = "https://files.pythonhosted.org/packages/f9/bf/176950a1792b2cd2102b8ffeb5133e1ed984547b75db47c25a67d3359f77/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:cabc348d87e913db6ab4aa100f01b08f481097838bdddf7c7a84b7575b7309ca", size = 23357 },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/9a02c1d335caabe5c4efb90e1b6e8ee944aa245c1aaaab8e8a618987d816/MarkupSafe-3.0.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:444dcda765c8a838eaae23112db52f1efaf750daddb2d9ca300bcae1039adc5c", size = 23344 },
+    { url = "https://files.pythonhosted.org/packages/ee/55/c271b57db36f748f0e04a759ace9f8f759ccf22b4960c270c78a394f58be/MarkupSafe-3.0.2-cp313-cp313-win32.whl", hash = "sha256:bcf3e58998965654fdaff38e58584d8937aa3096ab5354d493c77d1fdd66d7a1", size = 15101 },
+    { url = "https://files.pythonhosted.org/packages/29/88/07df22d2dd4df40aba9f3e402e6dc1b8ee86297dddbad4872bd5e7b0094f/MarkupSafe-3.0.2-cp313-cp313-win_amd64.whl", hash = "sha256:e6a2a455bd412959b57a172ce6328d2dd1f01cb2135efda2e4576e8a23fa3b0f", size = 15603 },
+    { url = "https://files.pythonhosted.org/packages/62/6a/8b89d24db2d32d433dffcd6a8779159da109842434f1dd2f6e71f32f738c/MarkupSafe-3.0.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:b5a6b3ada725cea8a5e634536b1b01c30bcdcd7f9c6fff4151548d5bf6b3a36c", size = 14510 },
+    { url = "https://files.pythonhosted.org/packages/7a/06/a10f955f70a2e5a9bf78d11a161029d278eeacbd35ef806c3fd17b13060d/MarkupSafe-3.0.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:a904af0a6162c73e3edcb969eeeb53a63ceeb5d8cf642fade7d39e7963a22ddb", size = 12486 },
+    { url = "https://files.pythonhosted.org/packages/34/cf/65d4a571869a1a9078198ca28f39fba5fbb910f952f9dbc5220afff9f5e6/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4aa4e5faecf353ed117801a068ebab7b7e09ffb6e1d5e412dc852e0da018126c", size = 25480 },
+    { url = "https://files.pythonhosted.org/packages/0c/e3/90e9651924c430b885468b56b3d597cabf6d72be4b24a0acd1fa0e12af67/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c0ef13eaeee5b615fb07c9a7dadb38eac06a0608b41570d8ade51c56539e509d", size = 23914 },
+    { url = "https://files.pythonhosted.org/packages/66/8c/6c7cf61f95d63bb866db39085150df1f2a5bd3335298f14a66b48e92659c/MarkupSafe-3.0.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d16a81a06776313e817c951135cf7340a3e91e8c1ff2fac444cfd75fffa04afe", size = 23796 },
+    { url = "https://files.pythonhosted.org/packages/bb/35/cbe9238ec3f47ac9a7c8b3df7a808e7cb50fe149dc7039f5f454b3fba218/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6381026f158fdb7c72a168278597a5e3a5222e83ea18f543112b2662a9b699c5", size = 25473 },
+    { url = "https://files.pythonhosted.org/packages/e6/32/7621a4382488aa283cc05e8984a9c219abad3bca087be9ec77e89939ded9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:3d79d162e7be8f996986c064d1c7c817f6df3a77fe3d6859f6f9e7be4b8c213a", size = 24114 },
+    { url = "https://files.pythonhosted.org/packages/0d/80/0985960e4b89922cb5a0bac0ed39c5b96cbc1a536a99f30e8c220a996ed9/MarkupSafe-3.0.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:131a3c7689c85f5ad20f9f6fb1b866f402c445b220c19fe4308c0b147ccd2ad9", size = 24098 },
+    { url = "https://files.pythonhosted.org/packages/82/78/fedb03c7d5380df2427038ec8d973587e90561b2d90cd472ce9254cf348b/MarkupSafe-3.0.2-cp313-cp313t-win32.whl", hash = "sha256:ba8062ed2cf21c07a9e295d5b8a2a5ce678b913b45fdf68c32d95d6c1291e0b6", size = 15208 },
+    { url = "https://files.pythonhosted.org/packages/4f/65/6079a46068dfceaeabb5dcad6d674f5f5c61a6fa5673746f42a9f4c233b3/MarkupSafe-3.0.2-cp313-cp313t-win_amd64.whl", hash = "sha256:e444a31f8db13eb18ada366ab3cf45fd4b31e4db1236a4448f68778c1d1a5a2f", size = 15739 },
 ]
 
 [[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198 },
 ]
 
 [[package]]
 name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263, upload-time = "2024-10-21T12:39:36.247Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/54/dd730b32ea14ea797530a4479b2ed46a6fb250f682a9cfb997e968bf0261/networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f", size = 1723263 },
 ]
 
 [[package]]
 name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348, upload-time = "2025-05-17T21:34:39.648Z" },
-    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362, upload-time = "2025-05-17T21:35:01.241Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103, upload-time = "2025-05-17T21:35:10.622Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382, upload-time = "2025-05-17T21:35:21.414Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462, upload-time = "2025-05-17T21:35:42.174Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618, upload-time = "2025-05-17T21:36:06.711Z" },
-    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511, upload-time = "2025-05-17T21:36:29.965Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783, upload-time = "2025-05-17T21:36:56.883Z" },
-    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506, upload-time = "2025-05-17T21:37:07.368Z" },
-    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190, upload-time = "2025-05-17T21:37:26.213Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828, upload-time = "2025-05-17T21:37:56.699Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006, upload-time = "2025-05-17T21:38:18.291Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765, upload-time = "2025-05-17T21:38:27.319Z" },
-    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736, upload-time = "2025-05-17T21:38:38.141Z" },
-    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719, upload-time = "2025-05-17T21:38:58.433Z" },
-    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072, upload-time = "2025-05-17T21:39:22.638Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213, upload-time = "2025-05-17T21:39:45.865Z" },
-    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632, upload-time = "2025-05-17T21:40:13.331Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532, upload-time = "2025-05-17T21:43:46.099Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885, upload-time = "2025-05-17T21:44:05.145Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467, upload-time = "2025-05-17T21:40:44Z" },
-    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144, upload-time = "2025-05-17T21:41:05.695Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217, upload-time = "2025-05-17T21:41:15.903Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014, upload-time = "2025-05-17T21:41:27.321Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935, upload-time = "2025-05-17T21:41:49.738Z" },
-    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122, upload-time = "2025-05-17T21:42:14.046Z" },
-    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143, upload-time = "2025-05-17T21:42:37.464Z" },
-    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260, upload-time = "2025-05-17T21:43:05.189Z" },
-    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225, upload-time = "2025-05-17T21:43:16.254Z" },
-    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374, upload-time = "2025-05-17T21:43:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/82/5d/c00588b6cf18e1da539b45d3598d3557084990dcc4331960c15ee776ee41/numpy-2.2.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:41c5a21f4a04fa86436124d388f6ed60a9343a6f767fced1a8a71c3fbca038ff", size = 20875348 },
+    { url = "https://files.pythonhosted.org/packages/66/ee/560deadcdde6c2f90200450d5938f63a34b37e27ebff162810f716f6a230/numpy-2.2.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:de749064336d37e340f640b05f24e9e3dd678c57318c7289d222a8a2f543e90c", size = 14119362 },
+    { url = "https://files.pythonhosted.org/packages/3c/65/4baa99f1c53b30adf0acd9a5519078871ddde8d2339dc5a7fde80d9d87da/numpy-2.2.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:894b3a42502226a1cac872f840030665f33326fc3dac8e57c607905773cdcde3", size = 5084103 },
+    { url = "https://files.pythonhosted.org/packages/cc/89/e5a34c071a0570cc40c9a54eb472d113eea6d002e9ae12bb3a8407fb912e/numpy-2.2.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:71594f7c51a18e728451bb50cc60a3ce4e6538822731b2933209a1f3614e9282", size = 6625382 },
+    { url = "https://files.pythonhosted.org/packages/f8/35/8c80729f1ff76b3921d5c9487c7ac3de9b2a103b1cd05e905b3090513510/numpy-2.2.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2618db89be1b4e05f7a1a847a9c1c0abd63e63a1607d892dd54668dd92faf87", size = 14018462 },
+    { url = "https://files.pythonhosted.org/packages/8c/3d/1e1db36cfd41f895d266b103df00ca5b3cbe965184df824dec5c08c6b803/numpy-2.2.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd83c01228a688733f1ded5201c678f0c53ecc1006ffbc404db9f7a899ac6249", size = 16527618 },
+    { url = "https://files.pythonhosted.org/packages/61/c6/03ed30992602c85aa3cd95b9070a514f8b3c33e31124694438d88809ae36/numpy-2.2.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:37c0ca431f82cd5fa716eca9506aefcabc247fb27ba69c5062a6d3ade8cf8f49", size = 15505511 },
+    { url = "https://files.pythonhosted.org/packages/b7/25/5761d832a81df431e260719ec45de696414266613c9ee268394dd5ad8236/numpy-2.2.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fe27749d33bb772c80dcd84ae7e8df2adc920ae8297400dabec45f0dedb3f6de", size = 18313783 },
+    { url = "https://files.pythonhosted.org/packages/57/0a/72d5a3527c5ebffcd47bde9162c39fae1f90138c961e5296491ce778e682/numpy-2.2.6-cp312-cp312-win32.whl", hash = "sha256:4eeaae00d789f66c7a25ac5f34b71a7035bb474e679f410e5e1a94deb24cf2d4", size = 6246506 },
+    { url = "https://files.pythonhosted.org/packages/36/fa/8c9210162ca1b88529ab76b41ba02d433fd54fecaf6feb70ef9f124683f1/numpy-2.2.6-cp312-cp312-win_amd64.whl", hash = "sha256:c1f9540be57940698ed329904db803cf7a402f3fc200bfe599334c9bd84a40b2", size = 12614190 },
+    { url = "https://files.pythonhosted.org/packages/f9/5c/6657823f4f594f72b5471f1db1ab12e26e890bb2e41897522d134d2a3e81/numpy-2.2.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0811bb762109d9708cca4d0b13c4f67146e3c3b7cf8d34018c722adb2d957c84", size = 20867828 },
+    { url = "https://files.pythonhosted.org/packages/dc/9e/14520dc3dadf3c803473bd07e9b2bd1b69bc583cb2497b47000fed2fa92f/numpy-2.2.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:287cc3162b6f01463ccd86be154f284d0893d2b3ed7292439ea97eafa8170e0b", size = 14143006 },
+    { url = "https://files.pythonhosted.org/packages/4f/06/7e96c57d90bebdce9918412087fc22ca9851cceaf5567a45c1f404480e9e/numpy-2.2.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f1372f041402e37e5e633e586f62aa53de2eac8d98cbfb822806ce4bbefcb74d", size = 5076765 },
+    { url = "https://files.pythonhosted.org/packages/73/ed/63d920c23b4289fdac96ddbdd6132e9427790977d5457cd132f18e76eae0/numpy-2.2.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:55a4d33fa519660d69614a9fad433be87e5252f4b03850642f88993f7b2ca566", size = 6617736 },
+    { url = "https://files.pythonhosted.org/packages/85/c5/e19c8f99d83fd377ec8c7e0cf627a8049746da54afc24ef0a0cb73d5dfb5/numpy-2.2.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f92729c95468a2f4f15e9bb94c432a9229d0d50de67304399627a943201baa2f", size = 14010719 },
+    { url = "https://files.pythonhosted.org/packages/19/49/4df9123aafa7b539317bf6d342cb6d227e49f7a35b99c287a6109b13dd93/numpy-2.2.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bc23a79bfabc5d056d106f9befb8d50c31ced2fbc70eedb8155aec74a45798f", size = 16526072 },
+    { url = "https://files.pythonhosted.org/packages/b2/6c/04b5f47f4f32f7c2b0e7260442a8cbcf8168b0e1a41ff1495da42f42a14f/numpy-2.2.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3143e4451880bed956e706a3220b4e5cf6172ef05fcc397f6f36a550b1dd868", size = 15503213 },
+    { url = "https://files.pythonhosted.org/packages/17/0a/5cd92e352c1307640d5b6fec1b2ffb06cd0dabe7d7b8227f97933d378422/numpy-2.2.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b4f13750ce79751586ae2eb824ba7e1e8dba64784086c98cdbbcc6a42112ce0d", size = 18316632 },
+    { url = "https://files.pythonhosted.org/packages/f0/3b/5cba2b1d88760ef86596ad0f3d484b1cbff7c115ae2429678465057c5155/numpy-2.2.6-cp313-cp313-win32.whl", hash = "sha256:5beb72339d9d4fa36522fc63802f469b13cdbe4fdab4a288f0c441b74272ebfd", size = 6244532 },
+    { url = "https://files.pythonhosted.org/packages/cb/3b/d58c12eafcb298d4e6d0d40216866ab15f59e55d148a5658bb3132311fcf/numpy-2.2.6-cp313-cp313-win_amd64.whl", hash = "sha256:b0544343a702fa80c95ad5d3d608ea3599dd54d4632df855e4c8d24eb6ecfa1c", size = 12610885 },
+    { url = "https://files.pythonhosted.org/packages/6b/9e/4bf918b818e516322db999ac25d00c75788ddfd2d2ade4fa66f1f38097e1/numpy-2.2.6-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:0bca768cd85ae743b2affdc762d617eddf3bcf8724435498a1e80132d04879e6", size = 20963467 },
+    { url = "https://files.pythonhosted.org/packages/61/66/d2de6b291507517ff2e438e13ff7b1e2cdbdb7cb40b3ed475377aece69f9/numpy-2.2.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fc0c5673685c508a142ca65209b4e79ed6740a4ed6b2267dbba90f34b0b3cfda", size = 14225144 },
+    { url = "https://files.pythonhosted.org/packages/e4/25/480387655407ead912e28ba3a820bc69af9adf13bcbe40b299d454ec011f/numpy-2.2.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:5bd4fc3ac8926b3819797a7c0e2631eb889b4118a9898c84f585a54d475b7e40", size = 5200217 },
+    { url = "https://files.pythonhosted.org/packages/aa/4a/6e313b5108f53dcbf3aca0c0f3e9c92f4c10ce57a0a721851f9785872895/numpy-2.2.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:fee4236c876c4e8369388054d02d0e9bb84821feb1a64dd59e137e6511a551f8", size = 6712014 },
+    { url = "https://files.pythonhosted.org/packages/b7/30/172c2d5c4be71fdf476e9de553443cf8e25feddbe185e0bd88b096915bcc/numpy-2.2.6-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e1dda9c7e08dc141e0247a5b8f49cf05984955246a327d4c48bda16821947b2f", size = 14077935 },
+    { url = "https://files.pythonhosted.org/packages/12/fb/9e743f8d4e4d3c710902cf87af3512082ae3d43b945d5d16563f26ec251d/numpy-2.2.6-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f447e6acb680fd307f40d3da4852208af94afdfab89cf850986c3ca00562f4fa", size = 16600122 },
+    { url = "https://files.pythonhosted.org/packages/12/75/ee20da0e58d3a66f204f38916757e01e33a9737d0b22373b3eb5a27358f9/numpy-2.2.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:389d771b1623ec92636b0786bc4ae56abafad4a4c513d36a55dce14bd9ce8571", size = 15586143 },
+    { url = "https://files.pythonhosted.org/packages/76/95/bef5b37f29fc5e739947e9ce5179ad402875633308504a52d188302319c8/numpy-2.2.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8e9ace4a37db23421249ed236fdcdd457d671e25146786dfc96835cd951aa7c1", size = 18385260 },
+    { url = "https://files.pythonhosted.org/packages/09/04/f2f83279d287407cf36a7a8053a5abe7be3622a4363337338f2585e4afda/numpy-2.2.6-cp313-cp313t-win32.whl", hash = "sha256:038613e9fb8c72b0a41f025a7e4c3f0b7a1b5d768ece4796b674c8f3fe13efff", size = 6377225 },
+    { url = "https://files.pythonhosted.org/packages/67/0e/35082d13c09c02c011cf21570543d202ad929d961c02a147493cb0c2bdf5/numpy-2.2.6-cp313-cp313t-win_amd64.whl", hash = "sha256:6031dd6dfecc0cf9f668681a37648373bddd6421fff6c66ec1624eed0180ee06", size = 12771374 },
 ]
 
 [[package]]
@@ -267,7 +266,8 @@ name = "nvidia-cublas-cu12"
 version = "12.4.5.8"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ae/71/1c91302526c45ab494c23f61c7a84aa568b8c1f9d196efa5993957faf906/nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_x86_64.whl", hash = "sha256:2fc8da60df463fdefa81e323eef2e36489e1c94335b5358bcb38360adf75ac9b", size = 363438805, upload-time = "2024-04-03T20:57:06.025Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7f/7fbae15a3982dc9595e49ce0f19332423b260045d0a6afe93cdbe2f1f624/nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0f8aa1706812e00b9f19dfe0cdb3999b092ccb8ca168c0db5b8ea712456fd9b3", size = 363333771 },
+    { url = "https://files.pythonhosted.org/packages/ae/71/1c91302526c45ab494c23f61c7a84aa568b8c1f9d196efa5993957faf906/nvidia_cublas_cu12-12.4.5.8-py3-none-manylinux2014_x86_64.whl", hash = "sha256:2fc8da60df463fdefa81e323eef2e36489e1c94335b5358bcb38360adf75ac9b", size = 363438805 },
 ]
 
 [[package]]
@@ -275,7 +275,8 @@ name = "nvidia-cuda-cupti-cu12"
 version = "12.4.127"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/42/f4f60238e8194a3106d06a058d494b18e006c10bb2b915655bd9f6ea4cb1/nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9dec60f5ac126f7bb551c055072b69d85392b13311fcc1bcda2202d172df30fb", size = 13813957, upload-time = "2024-04-03T20:55:01.564Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b5/9fb3d00386d3361b03874246190dfec7b206fd74e6e287b26a8fcb359d95/nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:79279b35cf6f91da114182a5ce1864997fd52294a87a16179ce275773799458a", size = 12354556 },
+    { url = "https://files.pythonhosted.org/packages/67/42/f4f60238e8194a3106d06a058d494b18e006c10bb2b915655bd9f6ea4cb1/nvidia_cuda_cupti_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:9dec60f5ac126f7bb551c055072b69d85392b13311fcc1bcda2202d172df30fb", size = 13813957 },
 ]
 
 [[package]]
@@ -283,7 +284,8 @@ name = "nvidia-cuda-nvrtc-cu12"
 version = "12.4.127"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/14/91ae57cd4db3f9ef7aa99f4019cfa8d54cb4caa7e00975df6467e9725a9f/nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a178759ebb095827bd30ef56598ec182b85547f1508941a3d560eb7ea1fbf338", size = 24640306, upload-time = "2024-04-03T20:56:01.463Z" },
+    { url = "https://files.pythonhosted.org/packages/77/aa/083b01c427e963ad0b314040565ea396f914349914c298556484f799e61b/nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:0eedf14185e04b76aa05b1fea04133e59f465b6f960c0cbf4e37c3cb6b0ea198", size = 24133372 },
+    { url = "https://files.pythonhosted.org/packages/2c/14/91ae57cd4db3f9ef7aa99f4019cfa8d54cb4caa7e00975df6467e9725a9f/nvidia_cuda_nvrtc_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a178759ebb095827bd30ef56598ec182b85547f1508941a3d560eb7ea1fbf338", size = 24640306 },
 ]
 
 [[package]]
@@ -291,7 +293,8 @@ name = "nvidia-cuda-runtime-cu12"
 version = "12.4.127"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/27/1795d86fe88ef397885f2e580ac37628ed058a92ed2c39dc8eac3adf0619/nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:64403288fa2136ee8e467cdc9c9427e0434110899d07c779f25b5c068934faa5", size = 883737, upload-time = "2024-04-03T20:54:51.355Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/aa/b656d755f474e2084971e9a297def515938d56b466ab39624012070cb773/nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:961fe0e2e716a2a1d967aab7caee97512f71767f852f67432d572e36cb3a11f3", size = 894177 },
+    { url = "https://files.pythonhosted.org/packages/ea/27/1795d86fe88ef397885f2e580ac37628ed058a92ed2c39dc8eac3adf0619/nvidia_cuda_runtime_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:64403288fa2136ee8e467cdc9c9427e0434110899d07c779f25b5c068934faa5", size = 883737 },
 ]
 
 [[package]]
@@ -302,7 +305,7 @@ dependencies = [
     { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/fd/713452cd72343f682b1c7b9321e23829f00b842ceaedcda96e742ea0b0b3/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl", hash = "sha256:165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f", size = 664752741, upload-time = "2024-04-22T15:24:15.253Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/fd/713452cd72343f682b1c7b9321e23829f00b842ceaedcda96e742ea0b0b3/nvidia_cudnn_cu12-9.1.0.70-py3-none-manylinux2014_x86_64.whl", hash = "sha256:165764f44ef8c61fcdfdfdbe769d687e06374059fbb388b6c89ecb0e28793a6f", size = 664752741 },
 ]
 
 [[package]]
@@ -313,7 +316,8 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/94/3266821f65b92b3138631e9c8e7fe1fb513804ac934485a8d05776e1dd43/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f083fc24912aa410be21fa16d157fed2055dab1cc4b6934a0e03cba69eb242b9", size = 211459117, upload-time = "2024-04-03T20:57:40.402Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/8a/0e728f749baca3fbeffad762738276e5df60851958be7783af121a7221e7/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:5dad8008fc7f92f5ddfa2101430917ce2ffacd86824914c82e28990ad7f00399", size = 211422548 },
+    { url = "https://files.pythonhosted.org/packages/27/94/3266821f65b92b3138631e9c8e7fe1fb513804ac934485a8d05776e1dd43/nvidia_cufft_cu12-11.2.1.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f083fc24912aa410be21fa16d157fed2055dab1cc4b6934a0e03cba69eb242b9", size = 211459117 },
 ]
 
 [[package]]
@@ -321,7 +325,8 @@ name = "nvidia-curand-cu12"
 version = "10.3.5.147"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/6d/44ad094874c6f1b9c654f8ed939590bdc408349f137f9b98a3a23ccec411/nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a88f583d4e0bb643c49743469964103aa59f7f708d862c3ddb0fc07f851e3b8b", size = 56305206, upload-time = "2024-04-03T20:58:08.722Z" },
+    { url = "https://files.pythonhosted.org/packages/80/9c/a79180e4d70995fdf030c6946991d0171555c6edf95c265c6b2bf7011112/nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_aarch64.whl", hash = "sha256:1f173f09e3e3c76ab084aba0de819c49e56614feae5c12f69883f4ae9bb5fad9", size = 56314811 },
+    { url = "https://files.pythonhosted.org/packages/8a/6d/44ad094874c6f1b9c654f8ed939590bdc408349f137f9b98a3a23ccec411/nvidia_curand_cu12-10.3.5.147-py3-none-manylinux2014_x86_64.whl", hash = "sha256:a88f583d4e0bb643c49743469964103aa59f7f708d862c3ddb0fc07f851e3b8b", size = 56305206 },
 ]
 
 [[package]]
@@ -334,7 +339,8 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/e1/5b9089a4b2a4790dfdea8b3a006052cfecff58139d5a4e34cb1a51df8d6f/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl", hash = "sha256:19e33fa442bcfd085b3086c4ebf7e8debc07cfe01e11513cc6d332fd918ac260", size = 127936057, upload-time = "2024-04-03T20:58:28.735Z" },
+    { url = "https://files.pythonhosted.org/packages/46/6b/a5c33cf16af09166845345275c34ad2190944bcc6026797a39f8e0a282e0/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_aarch64.whl", hash = "sha256:d338f155f174f90724bbde3758b7ac375a70ce8e706d70b018dd3375545fc84e", size = 127634111 },
+    { url = "https://files.pythonhosted.org/packages/3a/e1/5b9089a4b2a4790dfdea8b3a006052cfecff58139d5a4e34cb1a51df8d6f/nvidia_cusolver_cu12-11.6.1.9-py3-none-manylinux2014_x86_64.whl", hash = "sha256:19e33fa442bcfd085b3086c4ebf7e8debc07cfe01e11513cc6d332fd918ac260", size = 127936057 },
 ]
 
 [[package]]
@@ -345,7 +351,8 @@ dependencies = [
     { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/f7/97a9ea26ed4bbbfc2d470994b8b4f338ef663be97b8f677519ac195e113d/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ea4f11a2904e2a8dc4b1833cc1b5181cde564edd0d5cd33e3c168eff2d1863f1", size = 207454763, upload-time = "2024-04-03T20:58:59.995Z" },
+    { url = "https://files.pythonhosted.org/packages/96/a9/c0d2f83a53d40a4a41be14cea6a0bf9e668ffcf8b004bd65633f433050c0/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_aarch64.whl", hash = "sha256:9d32f62896231ebe0480efd8a7f702e143c98cfaa0e8a76df3386c1ba2b54df3", size = 207381987 },
+    { url = "https://files.pythonhosted.org/packages/db/f7/97a9ea26ed4bbbfc2d470994b8b4f338ef663be97b8f677519ac195e113d/nvidia_cusparse_cu12-12.3.1.170-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ea4f11a2904e2a8dc4b1833cc1b5181cde564edd0d5cd33e3c168eff2d1863f1", size = 207454763 },
 ]
 
 [[package]]
@@ -353,7 +360,8 @@ name = "nvidia-cusparselt-cu12"
 version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/a8/bcbb63b53a4b1234feeafb65544ee55495e1bb37ec31b999b963cbccfd1d/nvidia_cusparselt_cu12-0.6.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:df2c24502fd76ebafe7457dbc4716b2fec071aabaed4fb7691a201cde03704d9", size = 150057751, upload-time = "2024-07-23T02:35:53.074Z" },
+    { url = "https://files.pythonhosted.org/packages/98/8e/675498726c605c9441cf46653bd29cb1b8666da1fb1469ffa25f67f20c58/nvidia_cusparselt_cu12-0.6.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:067a7f6d03ea0d4841c85f0c6f1991c5dda98211f6302cb83a4ab234ee95bef8", size = 149422781 },
+    { url = "https://files.pythonhosted.org/packages/78/a8/bcbb63b53a4b1234feeafb65544ee55495e1bb37ec31b999b963cbccfd1d/nvidia_cusparselt_cu12-0.6.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:df2c24502fd76ebafe7457dbc4716b2fec071aabaed4fb7691a201cde03704d9", size = 150057751 },
 ]
 
 [[package]]
@@ -361,7 +369,7 @@ name = "nvidia-nccl-cu12"
 version = "2.21.5"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/df/99/12cd266d6233f47d00daf3a72739872bdc10267d0383508b0b9c84a18bb6/nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:8579076d30a8c24988834445f8d633c697d42397e92ffc3f63fa26766d25e0a0", size = 188654414, upload-time = "2024-04-03T15:32:57.427Z" },
+    { url = "https://files.pythonhosted.org/packages/df/99/12cd266d6233f47d00daf3a72739872bdc10267d0383508b0b9c84a18bb6/nvidia_nccl_cu12-2.21.5-py3-none-manylinux2014_x86_64.whl", hash = "sha256:8579076d30a8c24988834445f8d633c697d42397e92ffc3f63fa26766d25e0a0", size = 188654414 },
 ]
 
 [[package]]
@@ -369,7 +377,8 @@ name = "nvidia-nvjitlink-cu12"
 version = "12.4.127"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ff/ff/847841bacfbefc97a00036e0fce5a0f086b640756dc38caea5e1bb002655/nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:06b3b9b25bf3f8af351d664978ca26a16d2c5127dbd53c0497e28d1fb9611d57", size = 21066810, upload-time = "2024-04-03T20:59:46.957Z" },
+    { url = "https://files.pythonhosted.org/packages/02/45/239d52c05074898a80a900f49b1615d81c07fceadd5ad6c4f86a987c0bc4/nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4abe7fef64914ccfa909bc2ba39739670ecc9e820c83ccc7a6ed414122599b83", size = 20552510 },
+    { url = "https://files.pythonhosted.org/packages/ff/ff/847841bacfbefc97a00036e0fce5a0f086b640756dc38caea5e1bb002655/nvidia_nvjitlink_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:06b3b9b25bf3f8af351d664978ca26a16d2c5127dbd53c0497e28d1fb9611d57", size = 21066810 },
 ]
 
 [[package]]
@@ -377,21 +386,22 @@ name = "nvidia-nvtx-cu12"
 version = "12.4.127"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/20/199b8713428322a2f22b722c62b8cc278cc53dffa9705d744484b5035ee9/nvidia_nvtx_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:781e950d9b9f60d8241ccea575b32f5105a5baf4c2351cab5256a24869f12a1a", size = 99144, upload-time = "2024-04-03T20:56:12.406Z" },
+    { url = "https://files.pythonhosted.org/packages/06/39/471f581edbb7804b39e8063d92fc8305bdc7a80ae5c07dbe6ea5c50d14a5/nvidia_nvtx_cu12-12.4.127-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7959ad635db13edf4fc65c06a6e9f9e55fc2f92596db928d169c0bb031e88ef3", size = 100417 },
+    { url = "https://files.pythonhosted.org/packages/87/20/199b8713428322a2f22b722c62b8cc278cc53dffa9705d744484b5035ee9/nvidia_nvtx_cu12-12.4.127-py3-none-manylinux2014_x86_64.whl", hash = "sha256:781e950d9b9f60d8241ccea575b32f5105a5baf4c2351cab5256a24869f12a1a", size = 99144 },
 ]
 
 [[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
 ]
 
 [[package]]
 name = "pamiq-core"
-version = "0.3.1"
+version = "0.4.0"
 source = { directory = "../../" }
 dependencies = [
     { name = "httpx" },
@@ -402,15 +412,14 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "gymnasium", marker = "extra == 'gym'", specifier = ">=1.1.1" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "httpx", marker = "extra == 'kbctl'", specifier = ">=0.28.1" },
     { name = "prompt-toolkit", specifier = ">=3.0.51" },
     { name = "pynput", marker = "extra == 'kbctl'", specifier = ">=1.8.1" },
     { name = "starlette", specifier = ">=0.46.1" },
     { name = "torch", marker = "extra == 'torch'", specifier = ">=2.0.0" },
     { name = "uvicorn", specifier = ">=0.34.0" },
 ]
-provides-extras = ["torch", "kbctl"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -435,50 +444,50 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "wcwidth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bb/6e/9d084c929dfe9e3bfe0c6a47e31f78a25c54627d64a66e884a8bf5474f1c/prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed", size = 428940, upload-time = "2025-04-15T09:18:47.731Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/6e/9d084c929dfe9e3bfe0c6a47e31f78a25c54627d64a66e884a8bf5474f1c/prompt_toolkit-3.0.51.tar.gz", hash = "sha256:931a162e3b27fc90c86f1b48bb1fb2c528c2761475e57c9c06de13311c7b54ed", size = 428940 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/4f/5249960887b1fbe561d9ff265496d170b55a735b76724f10ef19f9e40716/prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07", size = 387810, upload-time = "2025-04-15T09:18:44.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/4f/5249960887b1fbe561d9ff265496d170b55a735b76724f10ef19f9e40716/prompt_toolkit-3.0.51-py3-none-any.whl", hash = "sha256:52742911fde84e2d423e2f9a4cf1de7d7ac4e51958f648d9540e0fb8db077b07", size = 387810 },
 ]
 
 [[package]]
 name = "protobuf"
 version = "6.31.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/f3/b9655a711b32c19720253f6f06326faf90580834e2e83f840472d752bc8b/protobuf-6.31.1.tar.gz", hash = "sha256:d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a", size = 441797, upload-time = "2025-05-28T19:25:54.947Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/f3/b9655a711b32c19720253f6f06326faf90580834e2e83f840472d752bc8b/protobuf-6.31.1.tar.gz", hash = "sha256:d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a", size = 441797 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/6f/6ab8e4bf962fd5570d3deaa2d5c38f0a363f57b4501047b5ebeb83ab1125/protobuf-6.31.1-cp310-abi3-win32.whl", hash = "sha256:7fa17d5a29c2e04b7d90e5e32388b8bfd0e7107cd8e616feef7ed3fa6bdab5c9", size = 423603, upload-time = "2025-05-28T19:25:41.198Z" },
-    { url = "https://files.pythonhosted.org/packages/44/3a/b15c4347dd4bf3a1b0ee882f384623e2063bb5cf9fa9d57990a4f7df2fb6/protobuf-6.31.1-cp310-abi3-win_amd64.whl", hash = "sha256:426f59d2964864a1a366254fa703b8632dcec0790d8862d30034d8245e1cd447", size = 435283, upload-time = "2025-05-28T19:25:44.275Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/c9/b9689a2a250264a84e66c46d8862ba788ee7a641cdca39bccf64f59284b7/protobuf-6.31.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f1227473dc43d44ed644425268eb7c2e488ae245d51c6866d19fe158e207402", size = 425604, upload-time = "2025-05-28T19:25:45.702Z" },
-    { url = "https://files.pythonhosted.org/packages/76/a1/7a5a94032c83375e4fe7e7f56e3976ea6ac90c5e85fac8576409e25c39c3/protobuf-6.31.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:a40fc12b84c154884d7d4c4ebd675d5b3b5283e155f324049ae396b95ddebc39", size = 322115, upload-time = "2025-05-28T19:25:47.128Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/b1/b59d405d64d31999244643d88c45c8241c58f17cc887e73bcb90602327f8/protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4ee898bf66f7a8b0bd21bce523814e6fbd8c6add948045ce958b73af7e8878c6", size = 321070, upload-time = "2025-05-28T19:25:50.036Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/af/ab3c51ab7507a7325e98ffe691d9495ee3d3aa5f589afad65ec920d39821/protobuf-6.31.1-py3-none-any.whl", hash = "sha256:720a6c7e6b77288b85063569baae8536671b39f15cc22037ec7045658d80489e", size = 168724, upload-time = "2025-05-28T19:25:53.926Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/6f/6ab8e4bf962fd5570d3deaa2d5c38f0a363f57b4501047b5ebeb83ab1125/protobuf-6.31.1-cp310-abi3-win32.whl", hash = "sha256:7fa17d5a29c2e04b7d90e5e32388b8bfd0e7107cd8e616feef7ed3fa6bdab5c9", size = 423603 },
+    { url = "https://files.pythonhosted.org/packages/44/3a/b15c4347dd4bf3a1b0ee882f384623e2063bb5cf9fa9d57990a4f7df2fb6/protobuf-6.31.1-cp310-abi3-win_amd64.whl", hash = "sha256:426f59d2964864a1a366254fa703b8632dcec0790d8862d30034d8245e1cd447", size = 435283 },
+    { url = "https://files.pythonhosted.org/packages/6a/c9/b9689a2a250264a84e66c46d8862ba788ee7a641cdca39bccf64f59284b7/protobuf-6.31.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f1227473dc43d44ed644425268eb7c2e488ae245d51c6866d19fe158e207402", size = 425604 },
+    { url = "https://files.pythonhosted.org/packages/76/a1/7a5a94032c83375e4fe7e7f56e3976ea6ac90c5e85fac8576409e25c39c3/protobuf-6.31.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:a40fc12b84c154884d7d4c4ebd675d5b3b5283e155f324049ae396b95ddebc39", size = 322115 },
+    { url = "https://files.pythonhosted.org/packages/fa/b1/b59d405d64d31999244643d88c45c8241c58f17cc887e73bcb90602327f8/protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4ee898bf66f7a8b0bd21bce523814e6fbd8c6add948045ce958b73af7e8878c6", size = 321070 },
+    { url = "https://files.pythonhosted.org/packages/f7/af/ab3c51ab7507a7325e98ffe691d9495ee3d3aa5f589afad65ec920d39821/protobuf-6.31.1-py3-none-any.whl", hash = "sha256:720a6c7e6b77288b85063569baae8536671b39f15cc22037ec7045658d80489e", size = 168724 },
 ]
 
 [[package]]
 name = "setuptools"
 version = "78.1.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/0db4da3bc908df06e5efae42b44e75c81dd52716e10192ff36d0c1c8e379/setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54", size = 1367827, upload-time = "2025-03-25T22:49:35.332Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/5a/0db4da3bc908df06e5efae42b44e75c81dd52716e10192ff36d0c1c8e379/setuptools-78.1.0.tar.gz", hash = "sha256:18fd474d4a82a5f83dac888df697af65afa82dec7323d09c3e37d1f14288da54", size = 1367827 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/21/f43f0a1fa8b06b32812e0975981f4677d28e0f3271601dc88ac5a5b83220/setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8", size = 1256108, upload-time = "2025-03-25T22:49:33.13Z" },
+    { url = "https://files.pythonhosted.org/packages/54/21/f43f0a1fa8b06b32812e0975981f4677d28e0f3271601dc88ac5a5b83220/setuptools-78.1.0-py3-none-any.whl", hash = "sha256:3e386e96793c8702ae83d17b853fb93d3e09ef82ec62722e61da5cd22376dcd8", size = 1256108 },
 ]
 
 [[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050 },
 ]
 
 [[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
 ]
 
 [[package]]
@@ -488,9 +497,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037 },
 ]
 
 [[package]]
@@ -500,9 +509,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mpmath" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ca/99/5a5b6f19ff9f083671ddf7b9632028436167cd3d33e11015754e41b249a4/sympy-1.13.1.tar.gz", hash = "sha256:9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f", size = 7533040, upload-time = "2024-07-19T09:26:51.238Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/99/5a5b6f19ff9f083671ddf7b9632028436167cd3d33e11015754e41b249a4/sympy-1.13.1.tar.gz", hash = "sha256:9cebf7e04ff162015ce31c9c6c9144daa34a93bd082f54fd8f12deca4f47515f", size = 7533040 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl", hash = "sha256:db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8", size = 6189177, upload-time = "2024-07-19T09:26:48.863Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fe/81695a1aa331a842b582453b605175f419fe8540355886031328089d840a/sympy-1.13.1-py3-none-any.whl", hash = "sha256:db36cdc64bf61b9b24578b6f7bab1ecdd2452cf008f34faa33776680c26d66f8", size = 6189177 },
 ]
 
 [[package]]
@@ -522,7 +531,7 @@ dependencies = [
     { name = "werkzeug" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/12/4f70e8e2ba0dbe72ea978429d8530b0333f0ed2140cc571a48802878ef99/tensorboard-2.19.0-py3-none-any.whl", hash = "sha256:5e71b98663a641a7ce8a6e70b0be8e1a4c0c45d48760b076383ac4755c35b9a0", size = 5503412, upload-time = "2025-02-12T08:17:27.21Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/12/4f70e8e2ba0dbe72ea978429d8530b0333f0ed2140cc571a48802878ef99/tensorboard-2.19.0-py3-none-any.whl", hash = "sha256:5e71b98663a641a7ce8a6e70b0be8e1a4c0c45d48760b076383ac4755c35b9a0", size = 5503412 },
 ]
 
 [[package]]
@@ -530,9 +539,9 @@ name = "tensorboard-data-server"
 version = "0.7.2"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl", hash = "sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb", size = 2356, upload-time = "2023-10-23T21:23:32.16Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/85/dabeaf902892922777492e1d253bb7e1264cadce3cea932f7ff599e53fea/tensorboard_data_server-0.7.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60", size = 4823598, upload-time = "2023-10-23T21:23:33.714Z" },
-    { url = "https://files.pythonhosted.org/packages/73/c6/825dab04195756cf8ff2e12698f22513b3db2f64925bdd41671bfb33aaa5/tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530", size = 6590363, upload-time = "2023-10-23T21:23:35.583Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/13/e503968fefabd4c6b2650af21e110aa8466fe21432cd7c43a84577a89438/tensorboard_data_server-0.7.2-py3-none-any.whl", hash = "sha256:7e0610d205889588983836ec05dc098e80f97b7e7bbff7e994ebb78f578d0ddb", size = 2356 },
+    { url = "https://files.pythonhosted.org/packages/b7/85/dabeaf902892922777492e1d253bb7e1264cadce3cea932f7ff599e53fea/tensorboard_data_server-0.7.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:9fe5d24221b29625dbc7328b0436ca7fc1c23de4acf4d272f1180856e32f9f60", size = 4823598 },
+    { url = "https://files.pythonhosted.org/packages/73/c6/825dab04195756cf8ff2e12698f22513b3db2f64925bdd41671bfb33aaa5/tensorboard_data_server-0.7.2-py3-none-manylinux_2_31_x86_64.whl", hash = "sha256:ef687163c24185ae9754ed5650eb5bc4d84ff257aabdc33f0cc6f74d8ba54530", size = 6590363 },
 ]
 
 [[package]]
@@ -563,14 +572,14 @@ dependencies = [
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/0c52d708144c2deb595cd22819a609f78fdd699b95ff6f0ebcd456e3c7c1/torch-2.6.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:2bb8987f3bb1ef2675897034402373ddfc8f5ef0e156e2d8cfc47cacafdda4a9", size = 766624563, upload-time = "2025-01-29T16:23:19.084Z" },
-    { url = "https://files.pythonhosted.org/packages/01/d6/455ab3fbb2c61c71c8842753b566012e1ed111e7a4c82e0e1c20d0c76b62/torch-2.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b789069020c5588c70d5c2158ac0aa23fd24a028f34a8b4fcb8fcb4d7efcf5fb", size = 95607867, upload-time = "2025-01-29T16:25:55.649Z" },
-    { url = "https://files.pythonhosted.org/packages/18/cf/ae99bd066571656185be0d88ee70abc58467b76f2f7c8bfeb48735a71fe6/torch-2.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:7e1448426d0ba3620408218b50aa6ada88aeae34f7a239ba5431f6c8774b1239", size = 204120469, upload-time = "2025-01-29T16:24:01.821Z" },
-    { url = "https://files.pythonhosted.org/packages/81/b4/605ae4173aa37fb5aa14605d100ff31f4f5d49f617928c9f486bb3aaec08/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:9a610afe216a85a8b9bc9f8365ed561535c93e804c2a317ef7fabcc5deda0989", size = 66532538, upload-time = "2025-01-29T16:24:18.976Z" },
-    { url = "https://files.pythonhosted.org/packages/24/85/ead1349fc30fe5a32cadd947c91bda4a62fbfd7f8c34ee61f6398d38fb48/torch-2.6.0-cp313-cp313-manylinux1_x86_64.whl", hash = "sha256:4874a73507a300a5d089ceaff616a569e7bb7c613c56f37f63ec3ffac65259cf", size = 766626191, upload-time = "2025-01-29T16:17:26.26Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/b0/26f06f9428b250d856f6d512413e9e800b78625f63801cbba13957432036/torch-2.6.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a0d5e1b9874c1a6c25556840ab8920569a7a4137afa8a63a32cee0bc7d89bd4b", size = 95611439, upload-time = "2025-01-29T16:21:21.061Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/9c/fc5224e9770c83faed3a087112d73147cd7c7bfb7557dcf9ad87e1dda163/torch-2.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:510c73251bee9ba02ae1cb6c9d4ee0907b3ce6020e62784e2d7598e0cfa4d6cc", size = 204126475, upload-time = "2025-01-29T16:21:55.394Z" },
-    { url = "https://files.pythonhosted.org/packages/88/8b/d60c0491ab63634763be1537ad488694d316ddc4a20eaadd639cedc53971/torch-2.6.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:ff96f4038f8af9f7ec4231710ed4549da1bdebad95923953a25045dcf6fd87e2", size = 66536783, upload-time = "2025-01-29T16:22:08.559Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/0c52d708144c2deb595cd22819a609f78fdd699b95ff6f0ebcd456e3c7c1/torch-2.6.0-cp312-cp312-manylinux1_x86_64.whl", hash = "sha256:2bb8987f3bb1ef2675897034402373ddfc8f5ef0e156e2d8cfc47cacafdda4a9", size = 766624563 },
+    { url = "https://files.pythonhosted.org/packages/01/d6/455ab3fbb2c61c71c8842753b566012e1ed111e7a4c82e0e1c20d0c76b62/torch-2.6.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b789069020c5588c70d5c2158ac0aa23fd24a028f34a8b4fcb8fcb4d7efcf5fb", size = 95607867 },
+    { url = "https://files.pythonhosted.org/packages/18/cf/ae99bd066571656185be0d88ee70abc58467b76f2f7c8bfeb48735a71fe6/torch-2.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:7e1448426d0ba3620408218b50aa6ada88aeae34f7a239ba5431f6c8774b1239", size = 204120469 },
+    { url = "https://files.pythonhosted.org/packages/81/b4/605ae4173aa37fb5aa14605d100ff31f4f5d49f617928c9f486bb3aaec08/torch-2.6.0-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:9a610afe216a85a8b9bc9f8365ed561535c93e804c2a317ef7fabcc5deda0989", size = 66532538 },
+    { url = "https://files.pythonhosted.org/packages/24/85/ead1349fc30fe5a32cadd947c91bda4a62fbfd7f8c34ee61f6398d38fb48/torch-2.6.0-cp313-cp313-manylinux1_x86_64.whl", hash = "sha256:4874a73507a300a5d089ceaff616a569e7bb7c613c56f37f63ec3ffac65259cf", size = 766626191 },
+    { url = "https://files.pythonhosted.org/packages/dd/b0/26f06f9428b250d856f6d512413e9e800b78625f63801cbba13957432036/torch-2.6.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a0d5e1b9874c1a6c25556840ab8920569a7a4137afa8a63a32cee0bc7d89bd4b", size = 95611439 },
+    { url = "https://files.pythonhosted.org/packages/c2/9c/fc5224e9770c83faed3a087112d73147cd7c7bfb7557dcf9ad87e1dda163/torch-2.6.0-cp313-cp313-win_amd64.whl", hash = "sha256:510c73251bee9ba02ae1cb6c9d4ee0907b3ce6020e62784e2d7598e0cfa4d6cc", size = 204126475 },
+    { url = "https://files.pythonhosted.org/packages/88/8b/d60c0491ab63634763be1537ad488694d316ddc4a20eaadd639cedc53971/torch-2.6.0-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:ff96f4038f8af9f7ec4231710ed4549da1bdebad95923953a25045dcf6fd87e2", size = 66536783 },
 ]
 
 [[package]]
@@ -578,17 +587,17 @@ name = "triton"
 version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/00/59500052cb1cf8cf5316be93598946bc451f14072c6ff256904428eaf03c/triton-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d9b215efc1c26fa7eefb9a157915c92d52e000d2bf83e5f69704047e63f125c", size = 253159365, upload-time = "2025-01-22T19:13:24.648Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/30/37a3384d1e2e9320331baca41e835e90a3767303642c7a80d4510152cbcf/triton-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5dfa23ba84541d7c0a531dfce76d8bcd19159d50a4a8b14ad01e91734a5c1b0", size = 253154278, upload-time = "2025-01-22T19:13:54.221Z" },
+    { url = "https://files.pythonhosted.org/packages/06/00/59500052cb1cf8cf5316be93598946bc451f14072c6ff256904428eaf03c/triton-3.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d9b215efc1c26fa7eefb9a157915c92d52e000d2bf83e5f69704047e63f125c", size = 253159365 },
+    { url = "https://files.pythonhosted.org/packages/c7/30/37a3384d1e2e9320331baca41e835e90a3767303642c7a80d4510152cbcf/triton-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e5dfa23ba84541d7c0a531dfce76d8bcd19159d50a4a8b14ad01e91734a5c1b0", size = 253154278 },
 ]
 
 [[package]]
 name = "typing-extensions"
 version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967, upload-time = "2025-04-10T14:19:05.416Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806, upload-time = "2025-04-10T14:19:03.967Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806 },
 ]
 
 [[package]]
@@ -599,9 +608,9 @@ dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/37/dd92f1f9cedb5eaf74d9999044306e06abe65344ff197864175dbbd91871/uvicorn-0.34.1.tar.gz", hash = "sha256:af981725fc4b7ffc5cb3b0e9eda6258a90c4b52cb2a83ce567ae0a7ae1757afc", size = 76755, upload-time = "2025-04-13T13:48:04.305Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/37/dd92f1f9cedb5eaf74d9999044306e06abe65344ff197864175dbbd91871/uvicorn-0.34.1.tar.gz", hash = "sha256:af981725fc4b7ffc5cb3b0e9eda6258a90c4b52cb2a83ce567ae0a7ae1757afc", size = 76755 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/38/a5801450940a858c102a7ad9e6150146a25406a119851c993148d56ab041/uvicorn-0.34.1-py3-none-any.whl", hash = "sha256:984c3a8c7ca18ebaad15995ee7401179212c59521e67bfc390c07fa2b8d2e065", size = 62404, upload-time = "2025-04-13T13:48:02.408Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/38/a5801450940a858c102a7ad9e6150146a25406a119851c993148d56ab041/uvicorn-0.34.1-py3-none-any.whl", hash = "sha256:984c3a8c7ca18ebaad15995ee7401179212c59521e67bfc390c07fa2b8d2e065", size = 62404 },
 ]
 
 [[package]]
@@ -627,9 +636,9 @@ requires-dist = [
 name = "wcwidth"
 version = "0.2.13"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301, upload-time = "2024-01-06T02:10:57.829Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/63/53559446a878410fc5a5974feb13d31d78d752eb18aeba59c7fef1af7598/wcwidth-0.2.13.tar.gz", hash = "sha256:72ea0c06399eb286d978fdedb6923a9eb47e1c486ce63e9b4e64fc18303972b5", size = 101301 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166, upload-time = "2024-01-06T02:10:55.763Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/84/fd2ba7aafacbad3c4201d395674fc6348826569da3c0937e75505ead3528/wcwidth-0.2.13-py2.py3-none-any.whl", hash = "sha256:3da69048e4540d84af32131829ff948f1e022c1c6bdb8d6102117aac784f6859", size = 34166 },
 ]
 
 [[package]]
@@ -639,7 +648,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925, upload-time = "2024-11-08T15:52:18.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/69/83029f1f6300c5fb2471d621ab06f6ec6b3324685a2ce0f9777fd4a8b71e/werkzeug-3.1.3.tar.gz", hash = "sha256:60723ce945c19328679790e3282cc758aa4a6040e4bb330f53d30fa546d44746", size = 806925 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498, upload-time = "2024-11-08T15:52:16.132Z" },
+    { url = "https://files.pythonhosted.org/packages/52/24/ab44c871b0f07f491e5d2ad12c9bd7358e527510618cb1b803a88e986db1/werkzeug-3.1.3-py3-none-any.whl", hash = "sha256:54b78bf3716d19a65be4fceccc0d1d7b89e608834989dfae50ea87564639213e", size = 224498 },
 ]

--- a/src/pamiq_core/__init__.py
+++ b/src/pamiq_core/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from importlib import metadata
 
-from . import data, interaction, model, time, trainer, typing, utils
+from . import data, interaction, model, time, trainer, utils
 from .data import DataBuffer, DataCollector, DataUser
 from .interaction import (
     Actuator,
@@ -37,7 +37,6 @@ __all__ = [
     "time",
     "trainer",
     "utils",
-    "typing",
     "DataBuffer",
     "DataCollector",
     "DataUser",

--- a/src/pamiq_core/data/__init__.py
+++ b/src/pamiq_core/data/__init__.py
@@ -1,12 +1,11 @@
 from . import impls
-from .buffer import DataBuffer, StepData
+from .buffer import DataBuffer
 from .container import DataCollectorsDict, DataUsersDict
 from .interface import DataCollector, DataUser
 
 __all__ = [
     "impls",
     "DataBuffer",
-    "StepData",
     "DataCollector",
     "DataUser",
     "DataCollectorsDict",

--- a/src/pamiq_core/data/buffer.py
+++ b/src/pamiq_core/data/buffer.py
@@ -13,8 +13,8 @@ class DataBuffer[T, R](ABC, PersistentStateMixin):
     buffer of fixed maximum size.
 
     Type Parameters:
-        T: The type of individual data elements.
-        R: The return type of the get_data() method.
+        - T: The type of individual data elements.
+        - R: The return type of the get_data() method.
     """
 
     def __init__(self, max_queue_size: int | None = None) -> None:

--- a/src/pamiq_core/data/buffer.py
+++ b/src/pamiq_core/data/buffer.py
@@ -22,6 +22,7 @@ class DataBuffer[T, R](ABC, PersistentStateMixin):
 
         Args:
             max_queue_size: Maximum number of samples to store in the collector's queue.
+                When the queue size exceeds this limit, old data will be deleted.
                 If None, the queue will have unlimited size (may cause memory issues).
 
         Raises:

--- a/src/pamiq_core/data/buffer.py
+++ b/src/pamiq_core/data/buffer.py
@@ -1,9 +1,6 @@
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Mapping
 
 from pamiq_core.state_persistence import PersistentStateMixin
-
-type StepData[T] = Mapping[str, T]
 
 
 class DataBuffer[T, R](ABC, PersistentStateMixin):
@@ -12,34 +9,26 @@ class DataBuffer[T, R](ABC, PersistentStateMixin):
 
     DataBuffer provides an interface for collecting and managing
     experience data generated during system execution. It maintains a
-    buffer of fixed maximum size that stores data for specified data
-    names.
+    buffer of fixed maximum size.
 
     Type Parameters:
         T: The type of data stored in each step.
         R: The return type of the get_data() method.
     """
 
-    def __init__(self, collecting_data_names: Iterable[str], max_size: int) -> None:
+    def __init__(self, max_size: int) -> None:
         """Initializes the DataBuffer.
 
         Args:
-            collecting_data_names: Names of data fields to collect and store.
             max_size: Maximum number of samples to store in the buffer.
 
         Raises:
             ValueError: If max_size is negative.
         """
         super().__init__()
-        self._collecting_data_names = set(collecting_data_names)
         if max_size < 0:
             raise ValueError("max_size must be non-negative")
         self._max_size = max_size
-
-    @property
-    def collecting_data_names(self) -> set[str]:
-        """Returns the set of data field names being collected."""
-        return self._collecting_data_names.copy()
 
     @property
     def max_size(self) -> int:
@@ -47,12 +36,11 @@ class DataBuffer[T, R](ABC, PersistentStateMixin):
         return self._max_size
 
     @abstractmethod
-    def add(self, step_data: StepData[T]) -> None:
+    def add(self, data: T) -> None:
         """Adds a new data sample to the buffer.
 
         Args:
-            step_data: Dictionary containing data for one step. Must contain
-                all fields specified in collecting_data_names.
+            data: Data element to add to the buffer.
         """
         pass
 

--- a/src/pamiq_core/data/buffer.py
+++ b/src/pamiq_core/data/buffer.py
@@ -12,7 +12,7 @@ class DataBuffer[T, R](ABC, PersistentStateMixin):
     buffer of fixed maximum size.
 
     Type Parameters:
-        T: The type of data stored in each step.
+        T: The type of individual data elements.
         R: The return type of the get_data() method.
     """
 

--- a/src/pamiq_core/data/container.py
+++ b/src/pamiq_core/data/container.py
@@ -11,7 +11,7 @@ from .buffer import DataBuffer
 from .interface import DataCollector, DataUser
 
 
-class DataUsersDict(UserDict[str, DataUser[Any, Any]], PersistentStateMixin):
+class DataUsersDict(UserDict[str, DataUser[Any]], PersistentStateMixin):
     """A dictionary mapping names to data users with helper methods for
     collector management.
 
@@ -37,7 +37,7 @@ class DataUsersDict(UserDict[str, DataUser[Any, Any]], PersistentStateMixin):
         return self._data_collectors_dict
 
     @override
-    def __setitem__(self, key: str, item: DataUser[Any, Any]) -> None:
+    def __setitem__(self, key: str, item: DataUser[Any]) -> None:
         """Set a data user in the dictionary and create its associated
         collector.
 
@@ -102,7 +102,7 @@ class DataUsersDict(UserDict[str, DataUser[Any, Any]], PersistentStateMixin):
             user.load_state(path / name)
 
 
-class DataCollectorsDict(UserDict[str, DataCollector[Any, Any]]):
+class DataCollectorsDict(UserDict[str, DataCollector[Any]]):
     """A dictionary for managing exclusive access to data collectors.
 
     Manages exclusive access to data collectors to ensure each collector
@@ -115,7 +115,7 @@ class DataCollectorsDict(UserDict[str, DataCollector[Any, Any]]):
         super().__init__(*args, **kwds)
         self._acquired_collectors: set[str] = set()
 
-    def acquire(self, collector_name: str) -> DataCollector[Any, Any]:
+    def acquire(self, collector_name: str) -> DataCollector[Any]:
         """Acquires a data collector for exclusive use within a step.
 
         Args:

--- a/src/pamiq_core/data/impls/__init__.py
+++ b/src/pamiq_core/data/impls/__init__.py
@@ -1,4 +1,12 @@
-from .random_replacement_buffer import RandomReplacementBuffer
-from .sequential_buffer import SequentialBuffer
+from .random_replacement_buffer import (
+    DictRandomReplacementBuffer,
+    RandomReplacementBuffer,
+)
+from .sequential_buffer import DictSequentialBuffer, SequentialBuffer
 
-__all__ = ["SequentialBuffer", "RandomReplacementBuffer"]
+__all__ = [
+    "SequentialBuffer",
+    "RandomReplacementBuffer",
+    "DictSequentialBuffer",
+    "DictRandomReplacementBuffer",
+]

--- a/src/pamiq_core/data/impls/random_replacement_buffer.py
+++ b/src/pamiq_core/data/impls/random_replacement_buffer.py
@@ -135,24 +135,23 @@ class RandomReplacementBuffer[T](DataBuffer[T, list[T]]):
     def save_state(self, path: Path) -> None:
         """Save the buffer state to the specified path.
 
-        Creates a directory at the given path and saves the data list.
+        Saves the data list to a pickle file with .pkl extension.
 
         Args:
-            path: Directory path where to save the buffer state.
+            path: File path where to save the buffer state (without extension).
         """
-        path.mkdir()
-        with open(path / "data.pkl", "wb") as f:
+        with open(path.with_suffix(".pkl"), "wb") as f:
             pickle.dump(self._data_list, f)
 
     @override
     def load_state(self, path: Path) -> None:
         """Load the buffer state from the specified path.
 
-        Loads data list from pickle file in the given directory.
+        Loads data list from pickle file with .pkl extension.
 
         Args:
-            path: Directory path from where to load the buffer state.
+            path: File path from where to load the buffer state (without extension).
         """
-        with open(path / "data.pkl", "rb") as f:
+        with open(path.with_suffix(".pkl"), "rb") as f:
             self._data_list = list(pickle.load(f))[: self.max_size]
         self._current_size = len(self._data_list)

--- a/src/pamiq_core/data/impls/random_replacement_buffer.py
+++ b/src/pamiq_core/data/impls/random_replacement_buffer.py
@@ -168,12 +168,7 @@ class DictRandomReplacementBuffer[T](DataBuffer[Mapping[str, T], dict[str, list[
     """Buffer implementation that stores dictionary data with random
     replacement.
 
-    This buffer stores dictionary data where each key has its own list of values.
-    When the buffer is full, new data may randomly replace existing entries based
-    on the configured replacement probability.
-
-    Type Parameters:
-        T: The type of values stored for each key.
+    See [`RandomReplacementBuffer`][pamiq_core.data.impls.RandomReplacementBuffer].
     """
 
     def __init__(
@@ -188,7 +183,7 @@ class DictRandomReplacementBuffer[T](DataBuffer[Mapping[str, T], dict[str, list[
         Args:
             keys: The keys that must be present in all data dictionaries.
 
-            Other arguments are same as `RandomReplacementBuffer`.
+        Other arguments are same as [`RandomReplacementBuffer`][pamiq_core.data.impls.RandomReplacementBuffer].
         """
         self._buffer = RandomReplacementBuffer[Mapping[str, T]](
             max_size, replace_probability, expected_survival_length

--- a/src/pamiq_core/data/impls/sequential_buffer.py
+++ b/src/pamiq_core/data/impls/sequential_buffer.py
@@ -60,24 +60,23 @@ class SequentialBuffer[T](DataBuffer[T, list[T]]):
     def save_state(self, path: Path) -> None:
         """Save the buffer state to the specified path.
 
-        Creates a directory at the given path and saves the data queue.
+        Saves the data queue to a pickle file with .pkl extension.
 
         Args:
-            path: Directory path where to save the buffer state
+            path: File path where to save the buffer state (without extension)
         """
-        path.mkdir()
-        with open(path / "data.pkl", "wb") as f:
+        with open(path.with_suffix(".pkl"), "wb") as f:
             pickle.dump(self._queue, f)
 
     @override
     def load_state(self, path: Path) -> None:
         """Load the buffer state from the specified path.
 
-        Loads data queue from pickle file in the given directory.
+        Loads data queue from pickle file with .pkl extension.
 
         Args:
-            path: Directory path from where to load the buffer state
+            path: File path from where to load the buffer state (without extension)
         """
-        with open(path / "data.pkl", "rb") as f:
+        with open(path.with_suffix(".pkl"), "rb") as f:
             self._queue = deque(pickle.load(f), maxlen=self.max_size)
         self._current_size = len(self._queue)

--- a/src/pamiq_core/data/impls/sequential_buffer.py
+++ b/src/pamiq_core/data/impls/sequential_buffer.py
@@ -25,6 +25,13 @@ class SequentialBuffer[T](DataBuffer[T, list[T]]):
         self._queue: deque[T] = deque(maxlen=max_size)
 
         self._current_size = 0
+        self._max_size = max_size
+
+    @property
+    def max_size(self) -> int:
+        """Returns the maximum number of data points that can be stored in the
+        buffer."""
+        return self._max_size
 
     @override
     def add(self, data: T) -> None:
@@ -35,7 +42,7 @@ class SequentialBuffer[T](DataBuffer[T, list[T]]):
         """
         self._queue.append(data)
 
-        if self._current_size < self.max_size:
+        if self._current_size < self._max_size:
             self._current_size += 1
 
     @override
@@ -78,5 +85,5 @@ class SequentialBuffer[T](DataBuffer[T, list[T]]):
             path: File path from where to load the buffer state (without extension)
         """
         with open(path.with_suffix(".pkl"), "rb") as f:
-            self._queue = deque(pickle.load(f), maxlen=self.max_size)
+            self._queue = deque(pickle.load(f), maxlen=self._max_size)
         self._current_size = len(self._queue)

--- a/src/pamiq_core/data/impls/sequential_buffer.py
+++ b/src/pamiq_core/data/impls/sequential_buffer.py
@@ -93,12 +93,7 @@ class SequentialBuffer[T](DataBuffer[T, list[T]]):
 class DictSequentialBuffer[T](DataBuffer[Mapping[str, T], dict[str, list[T]]]):
     """Buffer implementation that stores dictionary data in sequential order.
 
-    This buffer stores dictionary data where each key has its own list of values.
-    Data is maintained in FIFO order, with the oldest entries being removed when
-    the buffer reaches its maximum size.
-
-    Type Parameters:
-        T: The type of values stored for each key.
+    See: [`SequentialBuffer`][pamiq_core.data.impls.SequentialBuffer]
     """
 
     def __init__(

--- a/src/pamiq_core/data/impls/sequential_buffer.py
+++ b/src/pamiq_core/data/impls/sequential_buffer.py
@@ -1,64 +1,51 @@
 import pickle
 from collections import deque
-from collections.abc import Iterable
 from pathlib import Path
 from typing import override
 
-from ..buffer import DataBuffer, StepData
+from ..buffer import DataBuffer
 
 
-class SequentialBuffer[T](DataBuffer[T, dict[str, list[T]]]):
+class SequentialBuffer[T](DataBuffer[T, list[T]]):
     """Implementation of DataBuffer that maintains data in sequential order.
 
-    This buffer stores collected data points in ordered queues,
-    preserving the insertion order. Each data field is stored in a
-    separate queue with a maximum size limit.
+    This buffer stores collected data points in an ordered queue,
+    preserving the insertion order with a maximum size limit.
     """
 
     @override
-    def __init__(self, collecting_data_names: Iterable[str], max_size: int):
+    def __init__(self, max_size: int):
         """Initialize a new SequentialBuffer.
 
         Args:
-            collecting_data_names: Names of data fields to collect.
             max_size: Maximum number of data points to store.
         """
-        super().__init__(collecting_data_names, max_size)
+        super().__init__(max_size)
 
-        self._queues_dict: dict[str, deque[T]] = {
-            name: deque(maxlen=max_size) for name in collecting_data_names
-        }
+        self._queue: deque[T] = deque(maxlen=max_size)
 
         self._current_size = 0
 
     @override
-    def add(self, step_data: StepData[T]) -> None:
+    def add(self, data: T) -> None:
         """Add a new data sample to the buffer.
 
         Args:
-            step_data: Dictionary containing data for one step. Must contain
-                all fields specified in collecting_data_names.
-
-        Raises:
-            KeyError: If a required data field is missing from step_data.
+            data: Data element to add to the buffer.
         """
-        for name in self.collecting_data_names:
-            if name not in step_data:
-                raise KeyError(f"Required data '{name}' not found in step_data")
-            self._queues_dict[name].append(step_data[name])
+        self._queue.append(data)
 
         if self._current_size < self.max_size:
             self._current_size += 1
 
     @override
-    def get_data(self) -> dict[str, list[T]]:
+    def get_data(self) -> list[T]:
         """Retrieve all stored data from the buffer.
 
         Returns:
-            Dictionary mapping data field names to lists of their values.
-            Each list preserves the original insertion order.
+            List of all stored data elements preserving the original insertion order.
         """
-        return {name: list(queue) for name, queue in self._queues_dict.items()}
+        return list(self._queue)
 
     @override
     def __len__(self) -> int:
@@ -73,27 +60,24 @@ class SequentialBuffer[T](DataBuffer[T, dict[str, list[T]]]):
     def save_state(self, path: Path) -> None:
         """Save the buffer state to the specified path.
 
-        Creates a directory at the given path and saves each data queue as a
-        separate pickle file.
+        Creates a directory at the given path and saves the data queue.
 
         Args:
             path: Directory path where to save the buffer state
         """
         path.mkdir()
-        for name, queue in self._queues_dict.items():
-            with open(path / f"{name}.pkl", "wb") as f:
-                pickle.dump(queue, f)
+        with open(path / "data.pkl", "wb") as f:
+            pickle.dump(self._queue, f)
 
     @override
     def load_state(self, path: Path) -> None:
         """Load the buffer state from the specified path.
 
-        Loads data queues from pickle files in the given directory.
+        Loads data queue from pickle file in the given directory.
 
         Args:
             path: Directory path from where to load the buffer state
         """
-        for name in self.collecting_data_names:
-            with open(path / f"{name}.pkl", "rb") as f:
-                queue = deque(pickle.load(f), maxlen=self.max_size)
-                self._queues_dict[name] = queue
+        with open(path / "data.pkl", "rb") as f:
+            self._queue = deque(pickle.load(f), maxlen=self.max_size)
+        self._current_size = len(self._queue)

--- a/src/pamiq_core/data/interface.py
+++ b/src/pamiq_core/data/interface.py
@@ -67,7 +67,7 @@ class DataUser[T, R](PersistentStateMixin):
     collection.
 
     Type Parameters:
-        T: The type of data stored in each step.
+        T: The type of individual data elements.
         R: The return type of the buffer's get_data() method.
     """
 
@@ -168,7 +168,7 @@ class DataCollector[T, R]:
     collection and transfer.
 
     Type Parameters:
-        T: The type of data stored in each step.
+        T: The type of individual data elements.
         R: The return type of the associated buffer's get_data() method.
     """
 

--- a/src/pamiq_core/data/interface.py
+++ b/src/pamiq_core/data/interface.py
@@ -103,11 +103,12 @@ class DataUser[T, R](PersistentStateMixin):
             self._timestamps.append(t)
 
     def get_data(self) -> R:
-        """Retrieve data from the buffer.
+        """Update and retrieve data from the buffer.
 
         Returns:
             Current data stored in the buffer.
         """
+        self.update()
         return self._buffer.get_data()
 
     def count_data_added_since(self, timestamp: float) -> int:

--- a/src/pamiq_core/data/interface.py
+++ b/src/pamiq_core/data/interface.py
@@ -18,7 +18,7 @@ class TimestampingQueue[T]:
     retrieve data along with their corresponding timestamps.
     """
 
-    def __init__(self, max_len: int) -> None:
+    def __init__(self, max_len: int | None = None) -> None:
         """Initialize queue with specified maximum length.
 
         Args:
@@ -78,7 +78,7 @@ class DataUser[T, R](PersistentStateMixin):
             buffer: Data buffer instance to store collected data.
         """
         self._buffer = buffer
-        self._timestamps: deque[float] = deque(maxlen=buffer.max_size)
+        self._timestamps: deque[float] = deque(maxlen=buffer.max_queue_size)
         # DataCollector instance is only accessed from DataUser and Container classes
         self._collector = DataCollector(self)
 
@@ -86,9 +86,9 @@ class DataUser[T, R](PersistentStateMixin):
         """Create empty timestamping queue for data collection.
 
         Returns:
-            New instance of TimestampingQueue with the buffer's max_size.
+            New instance of TimestampingQueue with the buffer's max_queue_size.
         """
-        return TimestampingQueue(self._buffer.max_size)
+        return TimestampingQueue(self._buffer.max_queue_size)
 
     def update(self) -> None:
         """Update buffer with collected data from the collector.
@@ -153,7 +153,7 @@ class DataUser[T, R](PersistentStateMixin):
         """
         self._buffer.load_state(path / "buffer")
         with open(path / "timestamps.pkl", "rb") as f:
-            self._timestamps = deque(pickle.load(f), maxlen=self._buffer.max_size)
+            self._timestamps = deque(pickle.load(f), maxlen=self._buffer.max_queue_size)
 
     def __len__(self) -> int:
         """Returns the current number of samples in the buffer."""

--- a/src/pamiq_core/data/interface.py
+++ b/src/pamiq_core/data/interface.py
@@ -201,6 +201,5 @@ class DataCollector[T, R]:
             TimestampingQueue containing the collected data.
         """
         with self._lock:
-            data = self._queue
-            self._queue = self._user.create_empty_queue()
-            return data
+            out, self._queue = self._queue, self._user.create_empty_queue()
+        return out

--- a/src/pamiq_core/interaction/agent.py
+++ b/src/pamiq_core/interaction/agent.py
@@ -116,7 +116,7 @@ class Agent[ObsType, ActType](
         """
         return self._inference_models[name]
 
-    def get_data_collector(self, name: str) -> DataCollector[Any, Any]:
+    def get_data_collector(self, name: str) -> DataCollector[Any]:
         """Acquires a data collector by name for exclusive use.
 
         This method acquires a data collector for exclusive use within

--- a/src/pamiq_core/testing.py
+++ b/src/pamiq_core/testing.py
@@ -106,19 +106,19 @@ def create_mock_models(
     return training_model, inference_model
 
 
-def create_mock_buffer(max_size: int = 1) -> MagicMock:
+def create_mock_buffer(max_queue_size: int = 1) -> MagicMock:
     """Create a mock data buffer for testing.
 
     Creates a MagicMock instance that mocks a DataBuffer with the specified
-    max_size parameter. This is useful for testing components that depend on
+    max_queue_size parameter. This is useful for testing components that depend on
     DataBuffer without implementing a full buffer.
 
     Args:
-        max_size: Maximum size of the buffer. Defaults to 1.
+        max_queue_size: Maximum size of the buffer. Defaults to 1.
 
     Returns:
         A MagicMock object that mocks a DataBuffer.
     """
     buf = MagicMock(DataBuffer)
-    buf.max_size = max_size
+    buf.max_queue_size = max_queue_size
     return buf

--- a/src/pamiq_core/trainer/base.py
+++ b/src/pamiq_core/trainer/base.py
@@ -84,7 +84,7 @@ class Trainer(ABC, PersistentStateMixin, ThreadEventMixin):
         self._retrieved_model_names.add(name)
         return model
 
-    def get_data_user(self, name: str) -> DataUser[Any, Any]:
+    def get_data_user(self, name: str) -> DataUser[Any]:
         """Retrieves the data user."""
         return self._data_users[name]
 

--- a/src/pamiq_core/typing/__init__.py
+++ b/src/pamiq_core/typing/__init__.py
@@ -1,6 +1,0 @@
-from .data import DataCollectorType, DataUserType
-
-__all__ = [
-    "DataCollectorType",
-    "DataUserType",
-]

--- a/src/pamiq_core/typing/data.py
+++ b/src/pamiq_core/typing/data.py
@@ -1,9 +1,0 @@
-from typing import Any
-
-from pamiq_core.data import DataCollector, DataUser
-
-# For Agent.get_data_collector
-type DataUserType[R] = DataUser[Any, R]
-
-# For Trainer.get_data_user
-type DataCollectorType[T] = DataCollector[T, Any]

--- a/tests/pamiq_core/data/helpers.py
+++ b/tests/pamiq_core/data/helpers.py
@@ -10,13 +10,15 @@ class MockDataBuffer[T](DataBuffer[T, list[T]]):
     functionality needed for testing higher-level components.
     """
 
-    def __init__(self, max_size: int) -> None:
-        super().__init__(max_size)
+    def __init__(self, max_queue_size: int | None = None) -> None:
+        super().__init__(max_queue_size)
+        # For mock, use a reasonable default if None
+        self._max_size = 100 if max_queue_size is None else max_queue_size
         self.data: list[T] = []
 
     @override
     def add(self, data: T) -> None:
-        if len(self.data) < self.max_size:
+        if len(self.data) < self._max_size:
             self.data.append(data)
 
     @override

--- a/tests/pamiq_core/data/helpers.py
+++ b/tests/pamiq_core/data/helpers.py
@@ -1,29 +1,27 @@
 from typing import override
 
-from pamiq_core.data.buffer import DataBuffer, StepData
+from pamiq_core.data.buffer import DataBuffer
 
 
-class MockDataBuffer(DataBuffer):
+class MockDataBuffer[T](DataBuffer[T, list[T]]):
     """Simple mock implementation of DataBuffer for testing.
 
     This implementation uses a list to store data and provides minimal
     functionality needed for testing higher-level components.
     """
 
-    def __init__(self, collecting_data_names: list[str], max_size: int) -> None:
-        super().__init__(collecting_data_names, max_size)
-        self.data: list[StepData] = []
+    def __init__(self, max_size: int) -> None:
+        super().__init__(max_size)
+        self.data: list[T] = []
 
     @override
-    def add(self, step_data: StepData) -> None:
+    def add(self, data: T) -> None:
         if len(self.data) < self.max_size:
-            self.data.append(step_data)
+            self.data.append(data)
 
     @override
-    def get_data(self):
-        return {
-            name: [d[name] for d in self.data] for name in self._collecting_data_names
-        }
+    def get_data(self) -> list[T]:
+        return self.data.copy()
 
     @override
     def __len__(self) -> int:

--- a/tests/pamiq_core/data/impls/test_random_replacement_buffer.py
+++ b/tests/pamiq_core/data/impls/test_random_replacement_buffer.py
@@ -14,62 +14,54 @@ class TestRandomReplacementBuffer:
     """Test suite for RandomReplacementBuffer class."""
 
     @pytest.fixture
-    def buffer(self) -> RandomReplacementBuffer[Any]:
+    def buffer(self) -> RandomReplacementBuffer[int]:
         """Fixture providing a standard RandomReplacementBuffer for tests."""
-        return RandomReplacementBuffer(["state", "action", "reward"], 5)
+        return RandomReplacementBuffer(5)
 
     def test_init(self):
         """Test RandomReplacementBuffer initialization with various
         parameters."""
         # Test with standard parameters
-        data_names = ["state", "action", "reward"]
         max_size = 10
-        buffer = RandomReplacementBuffer(data_names, max_size)
+        buffer = RandomReplacementBuffer[int](max_size)
 
         assert buffer.max_size == max_size
-        assert buffer.collecting_data_names == set(data_names)
         assert buffer._replace_probability == 1.0
         assert buffer._current_size == 0
         assert not buffer.is_full
 
         # Test with custom replace probability
-        buffer = RandomReplacementBuffer(data_names, max_size, replace_probability=0.5)
+        buffer = RandomReplacementBuffer[int](max_size, replace_probability=0.5)
         assert buffer._replace_probability == 0.5
 
         # Test with invalid replace probability
         with pytest.raises(ValueError):
-            RandomReplacementBuffer(data_names, max_size, replace_probability=-0.1)
+            RandomReplacementBuffer[int](max_size, replace_probability=-0.1)
 
         with pytest.raises(ValueError):
-            RandomReplacementBuffer(data_names, max_size, replace_probability=1.1)
+            RandomReplacementBuffer[int](max_size, replace_probability=1.1)
 
     def test_init_with_expected_survival_length(self):
         """Test initialization with expected_survival_length parameter."""
-        data_names = ["state", "action", "reward"]
         max_size = 10
 
         # Test with expected_survival_length only
-        buffer = RandomReplacementBuffer(
-            data_names, max_size, expected_survival_length=20
-        )
+        buffer = RandomReplacementBuffer[int](max_size, expected_survival_length=20)
 
         # Should compute probability automatically
         assert 0.0 <= buffer._replace_probability <= 1.0
         assert buffer.max_size == max_size
-        assert buffer.collecting_data_names == set(data_names)
 
     def test_init_with_both_parameters_raises_error(self):
         """Test that specifying both replace_probability and
         expected_survival_length raises ValueError."""
-        data_names = ["state", "action", "reward"]
         max_size = 10
 
         with pytest.raises(
             ValueError,
             match="Cannot specify both replace_probability and expected_survival_length",
         ):
-            RandomReplacementBuffer(
-                data_names,
+            RandomReplacementBuffer[int](
                 max_size,
                 replace_probability=0.5,
                 expected_survival_length=20,
@@ -78,10 +70,9 @@ class TestRandomReplacementBuffer:
     def test_init_with_none_parameters(self):
         """Test initialization when both parameters are None (should default to
         1.0)."""
-        data_names = ["state", "action", "reward"]
         max_size = 10
 
-        buffer = RandomReplacementBuffer(data_names, max_size)
+        buffer = RandomReplacementBuffer[int](max_size)
         assert buffer._replace_probability == 1.0
 
     @pytest.mark.parametrize(
@@ -107,52 +98,44 @@ class TestRandomReplacementBuffer:
             0.0 <= probability <= 1.0
         ), f"Probability {probability} out of range for max_size={max_size}, survival_length={survival_length}"
 
-    def test_add_and_get_data(self, buffer: RandomReplacementBuffer[Any]):
+    def test_add_and_get_data(self, buffer: RandomReplacementBuffer[int]):
         """Test adding data to the buffer and retrieving it."""
-        # Sample data
-        sample1 = {"state": [1.0, 0.0], "action": 1, "reward": 0.5}
-        sample2 = {"state": [0.0, 1.0], "action": 0, "reward": -0.5}
-
         # Add data
-        buffer.add(sample1)
+        buffer.add(1)
 
         # Check data retrieval after adding one sample
         data = buffer.get_data()
-        assert data["state"] == [[1.0, 0.0]]
-        assert data["action"] == [1]
-        assert data["reward"] == [0.5]
-        assert buffer._current_size == 1
+        assert data == [1]
+        assert len(buffer) == 1
 
         # Add another sample
-        buffer.add(sample2)
+        buffer.add(2)
 
         # Check data retrieval after adding second sample
         data = buffer.get_data()
-        assert data["state"] == [[1.0, 0.0], [0.0, 1.0]]
-        assert data["action"] == [1, 0]
-        assert data["reward"] == [0.5, -0.5]
-        assert buffer._current_size == 2
+        assert data == [1, 2]
+        assert len(buffer) == 2
 
     def test_is_full_property(self):
         """Test the is_full property correctly reports buffer fullness."""
-        buffer = RandomReplacementBuffer(["value"], 3)
+        buffer = RandomReplacementBuffer[int](3)
 
         assert not buffer.is_full
 
         # Fill the buffer
         for i in range(3):
-            buffer.add({"value": i})
+            buffer.add(i)
 
         assert buffer.is_full
 
     def test_replacement_when_full(self, monkeypatch):
         """Test the random replacement behavior when buffer is full."""
         # Create a small buffer
-        buffer = RandomReplacementBuffer(["value"], 2)
+        buffer = RandomReplacementBuffer[str](2)
 
         # Fill the buffer
-        buffer.add({"value": "A"})
-        buffer.add({"value": "B"})
+        buffer.add("A")
+        buffer.add("B")
         assert buffer.is_full
 
         # Mock random functions to get deterministic behavior
@@ -162,73 +145,61 @@ class TestRandomReplacementBuffer:
         )  # Always replace first element
 
         # Add another item
-        buffer.add({"value": "C"})
+        buffer.add("C")
 
         # Check that first element was replaced
-        assert buffer.get_data()["value"] == ["C", "B"]
+        assert buffer.get_data() == ["C", "B"]
 
     def test_skip_replacement(self, monkeypatch):
         """Test that replacement is skipped based on probability."""
         # Create a buffer with low replacement probability
-        buffer = RandomReplacementBuffer(["value"], 2, replace_probability=0.3)
+        buffer = RandomReplacementBuffer[str](2, replace_probability=0.3)
 
         # Fill the buffer
-        buffer.add({"value": "A"})
-        buffer.add({"value": "B"})
+        buffer.add("A")
+        buffer.add("B")
         assert buffer.is_full
 
         # Mock random to always be above the replacement probability
         monkeypatch.setattr(random, "random", lambda: 0.9)
 
         # Try to add another item
-        buffer.add({"value": "C"})
+        buffer.add("C")
 
         # Check that no replacement occurred
-        assert buffer.get_data()["value"] == ["A", "B"]
+        assert buffer.get_data() == ["A", "B"]
 
-    def test_missing_data_field(self, buffer: RandomReplacementBuffer[Any]):
-        """Test adding data with missing required fields raises KeyError."""
-        incomplete_data = {"state": [1.0, 0.0], "action": 1}  # Missing 'reward'
-
-        with pytest.raises(
-            KeyError, match="Required data 'reward' not found in step_data"
-        ):
-            buffer.add(incomplete_data)
-
-    def test_get_data_returns_copy(self, buffer: RandomReplacementBuffer[Any]):
+    def test_get_data_returns_copy(self, buffer: RandomReplacementBuffer[int]):
         """Test that get_data returns a copy that doesn't affect the internal
         state."""
-        buffer.add({"state": [1.0], "action": 1, "reward": 0.5})
+        buffer.add(1)
 
         # Get data and modify it
         data = buffer.get_data()
-        data["state"].append([2.0])
+        data.append(2)
 
         # Verify internal state is unchanged
         new_data = buffer.get_data()
-        assert new_data["state"] == [[1.0]]
-        assert len(new_data["state"]) == 1
+        assert new_data == [1]
+        assert len(new_data) == 1
 
     def test_save_and_load_state(
-        self, buffer: RandomReplacementBuffer[Any], tmp_path: Path
+        self, buffer: RandomReplacementBuffer[int], tmp_path: Path
     ):
         """Test saving and loading the buffer state."""
         # Add some data to the buffer
-        buffer.add({"state": [1.0, 0.0], "action": 1, "reward": 0.5})
-        buffer.add({"state": [0.0, 1.0], "action": 0, "reward": -0.5})
+        buffer.add(1)
+        buffer.add(2)
 
         # Save state
         save_path = tmp_path / "test_buffer"
         buffer.save_state(save_path)
 
-        # Verify files were created
-        for name in buffer.collecting_data_names:
-            assert (save_path / f"{name}.pkl").exists()
+        # Verify file was created
+        assert (save_path / "data.pkl").exists()
 
         # Create a new buffer and load state
-        new_buffer = RandomReplacementBuffer(
-            buffer.collecting_data_names, buffer.max_size
-        )
+        new_buffer = RandomReplacementBuffer[int](buffer.max_size)
         new_buffer.load_state(save_path)
 
         # Check that loaded data matches original
@@ -238,65 +209,36 @@ class TestRandomReplacementBuffer:
         assert loaded_data == original_data
         assert new_buffer._current_size == buffer._current_size
 
-    def test_load_state_inconsistent_data(
-        self, buffer: RandomReplacementBuffer[Any], tmp_path: Path
-    ):
-        """Test loading state with inconsistent data lengths raises
-        ValueError."""
-        # Add some data to the buffer
-        buffer.add({"state": [1.0], "action": 1, "reward": 0.5})
-
-        # Save state
-        save_path = tmp_path / "test_buffer"
-        buffer.save_state(save_path)
-
-        # Corrupt one of the saved files
-        with open(save_path / "state.pkl", "wb") as f:
-            pickle.dump([[1.0], [2.0]], f)  # Different length
-
-        # Create a new buffer and try to load inconsistent state
-        new_buffer = RandomReplacementBuffer(
-            buffer.collecting_data_names, buffer.max_size
-        )
-        with pytest.raises(
-            ValueError, match="Inconsistent list lengths in loaded data"
-        ):
-            new_buffer.load_state(save_path)
-
     def test_save_and_load_state_max_size(
-        self, buffer: RandomReplacementBuffer[Any], tmp_path: Path
+        self, buffer: RandomReplacementBuffer[int], tmp_path: Path
     ):
-        """Test saving and loading the buffer state."""
+        """Test saving and loading the buffer state with smaller max_size."""
         # Add some data to the buffer
-        buffer.add({"state": [1.0, 0.0], "action": 1, "reward": 0.5})
-        buffer.add({"state": [0.0, 1.0], "action": 0, "reward": -0.5})
+        buffer.add(1)
+        buffer.add(2)
 
         # Save state
         save_path = tmp_path / "test_buffer"
         buffer.save_state(save_path)
 
-        # Verify files were created
-        for name in buffer.collecting_data_names:
-            assert (save_path / f"{name}.pkl").exists()
+        # Verify file was created
+        assert (save_path / "data.pkl").exists()
 
-        # Create a new buffer and load state
-        new_buffer = RandomReplacementBuffer(buffer.collecting_data_names, max_size=1)
+        # Create a new buffer with smaller max_size and load state
+        new_buffer = RandomReplacementBuffer[int](max_size=1)
         new_buffer.load_state(save_path)
 
-        # Check that loaded data matches original
-        original_data = buffer.get_data()
+        # Check that loaded data is truncated to new max_size
         loaded_data = new_buffer.get_data()
-
-        for key in buffer.collecting_data_names:
-            assert loaded_data[key] == original_data[key][:1]
+        assert loaded_data == [1]
         assert new_buffer._current_size == 1
 
-    def test_len(self, buffer: RandomReplacementBuffer[Any]):
+    def test_len(self, buffer: RandomReplacementBuffer[int]):
         """Test the __len__ method returns the correct buffer size."""
         assert len(buffer) == 0
 
-        buffer.add({"state": [1.0, 0.0], "action": 1, "reward": 0.5})
+        buffer.add(1)
         assert len(buffer) == 1
 
-        buffer.add({"state": [0.0, 1.0], "action": 0, "reward": -0.5})
+        buffer.add(2)
         assert len(buffer) == 2

--- a/tests/pamiq_core/data/impls/test_random_replacement_buffer.py
+++ b/tests/pamiq_core/data/impls/test_random_replacement_buffer.py
@@ -27,7 +27,7 @@ class TestRandomReplacementBuffer:
 
         assert buffer.max_size == max_size
         assert buffer._replace_probability == 1.0
-        assert buffer._current_size == 0
+        assert len(buffer) == 0
         assert not buffer.is_full
 
         # Test with custom replace probability
@@ -195,8 +195,8 @@ class TestRandomReplacementBuffer:
         save_path = tmp_path / "test_buffer"
         buffer.save_state(save_path)
 
-        # Verify file was created
-        assert (save_path / "data.pkl").exists()
+        # Verify file was created with .pkl extension
+        assert save_path.with_suffix(".pkl").exists()
 
         # Create a new buffer and load state
         new_buffer = RandomReplacementBuffer[int](buffer.max_size)
@@ -207,7 +207,7 @@ class TestRandomReplacementBuffer:
         loaded_data = new_buffer.get_data()
 
         assert loaded_data == original_data
-        assert new_buffer._current_size == buffer._current_size
+        assert len(new_buffer) == len(buffer)
 
     def test_save_and_load_state_max_size(
         self, buffer: RandomReplacementBuffer[int], tmp_path: Path
@@ -221,8 +221,8 @@ class TestRandomReplacementBuffer:
         save_path = tmp_path / "test_buffer"
         buffer.save_state(save_path)
 
-        # Verify file was created
-        assert (save_path / "data.pkl").exists()
+        # Verify file was created with .pkl extension
+        assert save_path.with_suffix(".pkl").exists()
 
         # Create a new buffer with smaller max_size and load state
         new_buffer = RandomReplacementBuffer[int](max_size=1)
@@ -231,7 +231,7 @@ class TestRandomReplacementBuffer:
         # Check that loaded data is truncated to new max_size
         loaded_data = new_buffer.get_data()
         assert loaded_data == [1]
-        assert new_buffer._current_size == 1
+        assert len(new_buffer) == 1
 
     def test_len(self, buffer: RandomReplacementBuffer[int]):
         """Test the __len__ method returns the correct buffer size."""

--- a/tests/pamiq_core/data/impls/test_sequential_buffer.py
+++ b/tests/pamiq_core/data/impls/test_sequential_buffer.py
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import pytest
 
-from pamiq_core.data.buffer import StepData
 from pamiq_core.data.impls.sequential_buffer import SequentialBuffer
 
 
@@ -10,100 +9,77 @@ class TestSequentialBuffer:
     """Test suite for SequentialBuffer."""
 
     @pytest.fixture
-    def buffer(self) -> SequentialBuffer:
+    def buffer(self) -> SequentialBuffer[int]:
         """Fixture providing a standard SequentialBuffer for tests."""
-        return SequentialBuffer(["state", "action", "reward"], 100)
+        return SequentialBuffer(100)
 
     def test_init(self):
         """Test SequentialBuffer initialization with various parameters."""
         # Test with standard parameters
-        data_names = ["state", "action", "reward"]
         max_size = 50
-        buffer = SequentialBuffer(data_names, max_size)
+        buffer = SequentialBuffer[int](max_size)
 
         assert buffer.max_size == max_size
-        assert buffer.collecting_data_names == set(data_names)
 
-    def test_add_and_get_data(self, buffer: SequentialBuffer):
+    def test_add_and_get_data(self, buffer: SequentialBuffer[int]):
         """Test adding data to the buffer and retrieving it."""
-        # Sample data
-        sample1: StepData = {"state": [1.0, 0.0], "action": 1, "reward": 0.5}
-        sample2: StepData = {"state": [0.0, 1.0], "action": 0, "reward": -0.5}
-
         # Add data
-        buffer.add(sample1)
+        buffer.add(1)
 
         # Check data retrieval after adding one sample
         data = buffer.get_data()
-        assert data["state"] == [[1.0, 0.0]]
-        assert data["action"] == [1]
-        assert data["reward"] == [0.5]
+        assert data == [1]
 
         # Add another sample
-        buffer.add(sample2)
+        buffer.add(2)
 
         # Check data retrieval after adding second sample
         data = buffer.get_data()
-        assert data["state"] == [[1.0, 0.0], [0.0, 1.0]]
-        assert data["action"] == [1, 0]
-        assert data["reward"] == [0.5, -0.5]
+        assert data == [1, 2]
 
     def test_max_size_constraint(self):
         """Test the buffer respects its maximum size constraint."""
         max_size = 3
-        buffer = SequentialBuffer(["value"], max_size)
+        buffer = SequentialBuffer[int](max_size)
 
         # Add more items than the max size
         for i in range(5):
-            buffer.add({"value": i})
+            buffer.add(i)
 
         # Check only the most recent max_size items are kept
         data = buffer.get_data()
-        assert data["value"] == [2, 3, 4]
-        assert len(data["value"]) == max_size
+        assert data == [2, 3, 4]
+        assert len(data) == max_size
 
-    def test_missing_data_field(self, buffer: SequentialBuffer):
-        """Test adding data with missing required fields raises KeyError."""
-        incomplete_data: StepData = {
-            "state": [1.0, 0.0],
-            "action": 1,
-        }  # Missing 'reward'
-
-        with pytest.raises(
-            KeyError, match="Required data 'reward' not found in step_data"
-        ):
-            buffer.add(incomplete_data)
-
-    def test_get_data_returns_copy(self, buffer: SequentialBuffer):
+    def test_get_data_returns_copy(self, buffer: SequentialBuffer[int]):
         """Test that get_data returns a copy that doesn't affect the internal
         state."""
-        buffer.add({"state": [1.0], "action": 1, "reward": 0.5})
+        buffer.add(1)
 
         # Get data and modify it
         data = buffer.get_data()
-        data["state"].append([2.0])
+        data.append(2)
 
         # Verify internal state is unchanged
         new_data = buffer.get_data()
-        assert new_data["state"] == [[1.0]]
-        assert len(new_data["state"]) == 1
+        assert new_data == [1]
+        assert len(new_data) == 1
 
-    def test_save_and_load_state(self, buffer: SequentialBuffer, tmp_path: Path):
+    def test_save_and_load_state(self, buffer: SequentialBuffer[int], tmp_path: Path):
         """Test saving and loading the buffer state."""
         # Add some data to the buffer
-        buffer.add({"state": [1.0, 0.0], "action": 1, "reward": 0.5})
-        buffer.add({"state": [0.0, 1.0], "action": 0, "reward": -0.5})
+        buffer.add(1)
+        buffer.add(2)
 
         # Save state
         save_path = tmp_path / "test_buffer"
         buffer.save_state(save_path)
 
-        # Verify files were created
-        for name in buffer.collecting_data_names:
-            assert (save_path / f"{name}.pkl").is_file()
+        # Verify file was created
+        assert (save_path / "data.pkl").is_file()
 
         # Create a new buffer and load state
-        new_buffer = SequentialBuffer(buffer.collecting_data_names, buffer.max_size)
+        new_buffer = SequentialBuffer[int](buffer.max_size)
         new_buffer.load_state(save_path)
 
         # Check that loaded data matches original
@@ -112,15 +88,12 @@ class TestSequentialBuffer:
 
         assert loaded_data == original_data
 
-        for name in buffer.collecting_data_names:
-            assert loaded_data[name] == original_data[name]
-
-    def test_len(self, buffer: SequentialBuffer):
+    def test_len(self, buffer: SequentialBuffer[int]):
         """Test the __len__ method returns the correct buffer size."""
         assert len(buffer) == 0
 
-        buffer.add({"state": [1.0, 0.0], "action": 1, "reward": 0.5})
+        buffer.add(1)
         assert len(buffer) == 1
 
-        buffer.add({"state": [0.0, 1.0], "action": 0, "reward": -0.5})
+        buffer.add(2)
         assert len(buffer) == 2

--- a/tests/pamiq_core/data/impls/test_sequential_buffer.py
+++ b/tests/pamiq_core/data/impls/test_sequential_buffer.py
@@ -2,7 +2,10 @@ from pathlib import Path
 
 import pytest
 
-from pamiq_core.data.impls.sequential_buffer import SequentialBuffer
+from pamiq_core.data.impls.sequential_buffer import (
+    DictSequentialBuffer,
+    SequentialBuffer,
+)
 
 
 class TestSequentialBuffer:
@@ -97,3 +100,111 @@ class TestSequentialBuffer:
 
         buffer.add(2)
         assert len(buffer) == 2
+
+
+class TestDictSequentialBuffer:
+    """Test suite for DictSequentialBuffer class."""
+
+    @pytest.mark.parametrize(
+        "max_size,expected",
+        [
+            (10, 10),
+            (100, 100),
+            (1, 1),
+        ],
+    )
+    def test_init_with_max_size(self, max_size, expected):
+        """Test initialization with different max_size values."""
+        buffer = DictSequentialBuffer[int](["a", "b"], max_size=max_size)
+        assert buffer.max_size == expected
+        assert len(buffer) == 0
+
+    def test_init_with_empty_keys(self):
+        """Test initialization with empty keys is allowed."""
+        buffer = DictSequentialBuffer[int]([], max_size=10)
+        assert len(buffer) == 0
+        assert buffer.get_data() == {}
+
+    @pytest.mark.parametrize(
+        "keys,data",
+        [
+            (["a", "b"], {"a": 1, "b": 2}),
+            ([], {}),  # Empty keys and data
+        ],
+    )
+    def test_add_valid_data(self, keys, data):
+        """Test adding valid data to buffer."""
+        buffer = DictSequentialBuffer[int](keys, max_size=10)
+        buffer.add(data)
+        assert len(buffer) == 1
+
+    @pytest.mark.parametrize(
+        "keys,data",
+        [
+            (["a", "b"], {"a": 1}),  # Missing key
+            (["a", "b"], {"a": 1, "b": 2, "c": 3}),  # Extra key
+            (["a"], {"b": 1}),  # Different key
+        ],
+    )
+    def test_add_invalid_data_raises(self, keys, data):
+        """Test adding invalid data raises ValueError."""
+        buffer = DictSequentialBuffer[int](keys, max_size=10)
+        with pytest.raises(ValueError, match="Data keys.*do not match expected keys"):
+            buffer.add(data)
+
+    def test_get_data_structure(self):
+        """Test get_data returns correct structure."""
+        buffer = DictSequentialBuffer[int](["x", "y"], max_size=3)
+
+        # Empty buffer
+        assert buffer.get_data() == {"x": [], "y": []}
+
+        # Add data
+        buffer.add({"x": 1, "y": 10})
+        buffer.add({"x": 2, "y": 20})
+
+        result = buffer.get_data()
+        assert result == {"x": [1, 2], "y": [10, 20]}
+
+    def test_sequential_order_preserved(self):
+        """Test that data maintains FIFO order."""
+        buffer = DictSequentialBuffer[int](["a"], max_size=5)
+
+        # Add data in order
+        for i in range(5):
+            buffer.add({"a": i})
+
+        assert buffer.get_data()["a"] == [0, 1, 2, 3, 4]
+
+    def test_oldest_removed_when_full(self):
+        """Test that oldest entries are removed when buffer is full."""
+        buffer = DictSequentialBuffer[int](["x", "y"], max_size=3)
+
+        # Add more than capacity
+        for i in range(5):
+            buffer.add({"x": i, "y": i * 10})
+
+        # Should keep only last 3
+        result = buffer.get_data()
+        assert result == {"x": [2, 3, 4], "y": [20, 30, 40]}
+        assert len(buffer) == 3
+
+    def test_save_and_load_state(self, tmp_path):
+        """Test state persistence."""
+        keys = ["a", "b"]
+        buffer = DictSequentialBuffer[float](keys, max_size=10)
+
+        # Add data
+        buffer.add({"a": 1.0, "b": 2.0})
+        buffer.add({"a": 3.0, "b": 4.0})
+
+        # Save
+        path = tmp_path / "state"
+        buffer.save_state(path)
+
+        # Load into new buffer
+        new_buffer = DictSequentialBuffer[float](keys, max_size=10)
+        new_buffer.load_state(path)
+
+        assert new_buffer.get_data() == buffer.get_data()
+        assert len(new_buffer) == len(buffer)

--- a/tests/pamiq_core/data/impls/test_sequential_buffer.py
+++ b/tests/pamiq_core/data/impls/test_sequential_buffer.py
@@ -75,8 +75,8 @@ class TestSequentialBuffer:
         save_path = tmp_path / "test_buffer"
         buffer.save_state(save_path)
 
-        # Verify file was created
-        assert (save_path / "data.pkl").is_file()
+        # Verify file was created with .pkl extension
+        assert save_path.with_suffix(".pkl").is_file()
 
         # Create a new buffer and load state
         new_buffer = SequentialBuffer[int](buffer.max_size)

--- a/tests/pamiq_core/data/test_buffer.py
+++ b/tests/pamiq_core/data/test_buffer.py
@@ -1,40 +1,32 @@
 from collections import deque
-from collections.abc import Iterable
 from typing import Any, override
 
 import pytest
 
-from pamiq_core.data.buffer import DataBuffer, StepData
+from pamiq_core.data.buffer import DataBuffer
 from pamiq_core.state_persistence import PersistentStateMixin
 
 
-class DataBufferImpl(DataBuffer):
+class DataBufferImpl(DataBuffer[Any, deque[Any]]):
     """Reference implementation of DataBuffer using deque.
 
     This implementation is closer to production usage and is used for
     testing the DataBuffer interface itself.
     """
 
-    def __init__(self, collecting_data_names: Iterable[str], max_size: int) -> None:
-        super().__init__(collecting_data_names, max_size)
-        self._buffer: dict[str, deque[Any]] = {
-            name: deque(maxlen=max_size) for name in collecting_data_names
-        }
-
+    def __init__(self, max_size: int) -> None:
+        super().__init__(max_size)
+        self._buffer: deque[Any] = deque(maxlen=max_size)
         self._current_size = 0
 
     @override
-    def add(self, step_data: StepData) -> None:
-        for name in self._collecting_data_names:
-            if name not in step_data:
-                raise KeyError(f"Required data '{name}' not found in step_data")
-            self._buffer[name].append(step_data[name])
-
+    def add(self, data: Any) -> None:
+        self._buffer.append(data)
         if self._current_size < self.max_size:
             self._current_size += 1
 
     @override
-    def get_data(self) -> dict[str, deque[Any]]:
+    def get_data(self) -> deque[Any]:
         return self._buffer.copy()
 
     @override
@@ -56,38 +48,15 @@ class TestDataBuffer:
 
     def test_init(self):
         """Test DataBuffer initialization with valid parameters."""
-        data_names = ["state", "action", "reward"]
         max_size = 1000
-        buffer = DataBufferImpl(data_names, max_size)
+        buffer = DataBufferImpl(max_size)
 
         assert buffer.max_size == max_size
-        assert buffer.collecting_data_names == set(data_names)
 
     def test_init_negative_size(self):
         """Test DataBuffer initialization with negative max_size raises
         ValueError."""
-        data_names = ["state", "action"]
         max_size = -1
 
         with pytest.raises(ValueError, match="max_size must be non-negative"):
-            DataBufferImpl(data_names, max_size)
-
-    def test_collecting_data_names_immutable(self):
-        """Test that collecting_data_names property returns a copy that cannot
-        affect the internal state."""
-        data_names = ["state", "action"]
-        buffer = DataBufferImpl(data_names, 100)
-
-        # Get the data names and try to modify them
-        names = buffer.collecting_data_names
-        names.add("reward")
-
-        # Original internal state should be unchanged
-        assert buffer.collecting_data_names == set(data_names)
-
-    def test_max_size_property(self):
-        """Test that max_size property returns the correct value."""
-        max_size = 500
-        buffer = DataBufferImpl(["state"], max_size)
-
-        assert buffer.max_size == max_size
+            DataBufferImpl(max_size)

--- a/tests/pamiq_core/data/test_buffer.py
+++ b/tests/pamiq_core/data/test_buffer.py
@@ -14,15 +14,17 @@ class DataBufferImpl(DataBuffer[Any, deque[Any]]):
     testing the DataBuffer interface itself.
     """
 
-    def __init__(self, max_size: int) -> None:
-        super().__init__(max_size)
-        self._buffer: deque[Any] = deque(maxlen=max_size)
+    def __init__(self, max_queue_size: int | None = None) -> None:
+        super().__init__(max_queue_size)
+        # For testing purposes, use a fixed buffer size
+        self._max_size = 1000 if max_queue_size is None else max_queue_size
+        self._buffer: deque[Any] = deque(maxlen=self._max_size)
         self._current_size = 0
 
     @override
     def add(self, data: Any) -> None:
         self._buffer.append(data)
-        if self._current_size < self.max_size:
+        if self._current_size < self._max_size:
             self._current_size += 1
 
     @override
@@ -48,15 +50,23 @@ class TestDataBuffer:
 
     def test_init(self):
         """Test DataBuffer initialization with valid parameters."""
-        max_size = 1000
-        buffer = DataBufferImpl(max_size)
+        max_queue_size = 1000
+        buffer = DataBufferImpl(max_queue_size)
 
-        assert buffer.max_size == max_size
+        assert buffer.max_queue_size == max_queue_size
 
     def test_init_negative_size(self):
-        """Test DataBuffer initialization with negative max_size raises
+        """Test DataBuffer initialization with negative max_queue_size raises
         ValueError."""
-        max_size = -1
+        max_queue_size = -1
 
-        with pytest.raises(ValueError, match="max_size must be non-negative"):
-            DataBufferImpl(max_size)
+        with pytest.raises(ValueError, match="max_queue_size must be non-negative"):
+            DataBufferImpl(max_queue_size)
+
+    def test_init_with_none_warns(self):
+        """Test DataBuffer initialization with None max_queue_size warns about
+        memory."""
+        with pytest.warns(RuntimeWarning, match="max_queue_size is None"):
+            buffer = DataBufferImpl(None)
+
+        assert buffer.max_queue_size is None

--- a/tests/pamiq_core/data/test_container.py
+++ b/tests/pamiq_core/data/test_container.py
@@ -11,14 +11,14 @@ from .helpers import MockDataBuffer
 
 class TestDataUsersDictAndCollectorsDict:
     @pytest.fixture
-    def buffers(self) -> dict[str, MockDataBuffer]:
+    def buffers(self) -> dict[str, MockDataBuffer[int]]:
         return {
-            "main": MockDataBuffer(["state"], 100),
-            "sub": MockDataBuffer(["action"], 100),
+            "main": MockDataBuffer[int](100),
+            "sub": MockDataBuffer[int](100),
         }
 
     @pytest.fixture
-    def users_dict(self, buffers: dict[str, MockDataBuffer]) -> DataUsersDict:
+    def users_dict(self, buffers: dict[str, MockDataBuffer[int]]) -> DataUsersDict:
         return DataUsersDict.from_data_buffers(buffers)
 
     @pytest.fixture
@@ -32,7 +32,7 @@ class TestDataUsersDictAndCollectorsDict:
         assert users_dict["sub"]._collector is collectors_dict["sub"]
 
     # DataUsersDict initialization tests
-    def test_from_data_buffers_dict(self, buffers: dict[str, MockDataBuffer]):
+    def test_from_data_buffers_dict(self, buffers: dict[str, MockDataBuffer[int]]):
         users_dict = DataUsersDict.from_data_buffers(buffers)
         assert len(users_dict) == 2
         assert all(isinstance(v, DataUser) for v in users_dict.values())
@@ -43,7 +43,7 @@ class TestDataUsersDictAndCollectorsDict:
         assert all(isinstance(v, DataCollector) for v in collectors_dict.values())
         assert set(collectors_dict.keys()) == {"main", "sub"}
 
-    def test_from_data_buffers_kwargs(self, buffers: dict[str, MockDataBuffer]):
+    def test_from_data_buffers_kwargs(self, buffers: dict[str, MockDataBuffer[int]]):
         users_dict = DataUsersDict.from_data_buffers(**buffers)
         assert len(users_dict) == 2
         assert all(isinstance(v, DataUser) for v in users_dict.values())
@@ -54,8 +54,8 @@ class TestDataUsersDictAndCollectorsDict:
         assert all(isinstance(v, DataCollector) for v in collectors_dict.values())
         assert set(collectors_dict.keys()) == {"main", "sub"}
 
-    def test_from_data_buffers_mixed(self, buffers: dict[str, MockDataBuffer]):
-        buffer3 = MockDataBuffer(["reward"], 100)
+    def test_from_data_buffers_mixed(self, buffers: dict[str, MockDataBuffer[int]]):
+        buffer3 = MockDataBuffer[int](100)
         users_dict = DataUsersDict.from_data_buffers(buffers, extra=buffer3)
         assert len(users_dict) == 3
         assert all(isinstance(v, DataUser) for v in users_dict.values())
@@ -71,7 +71,7 @@ class TestDataUsersDictAndCollectorsDict:
         self,
     ):
         users_dict = DataUsersDict()
-        user = DataUser(MockDataBuffer(["reward"], 100))
+        user = DataUser(MockDataBuffer[int](100))
         users_dict["test"] = user
 
         assert "test" in users_dict

--- a/tests/pamiq_core/data/test_interface.py
+++ b/tests/pamiq_core/data/test_interface.py
@@ -86,12 +86,12 @@ class TestDataUserAndCollector:
         return MockDataBuffer[int](self.MAX_SIZE)
 
     @pytest.fixture
-    def data_user(self, buffer: MockDataBuffer[int]) -> DataUser[int, list[int]]:
+    def data_user(self, buffer: MockDataBuffer[int]) -> DataUser[list[int]]:
         """Fixture providing DataUser instance."""
         return DataUser(buffer)
 
     def test_basic_collection_and_update(
-        self, data_user: DataUser[int, list[int]], buffer: MockDataBuffer[int], mocker
+        self, data_user: DataUser[list[int]], buffer: MockDataBuffer[int], mocker
     ):
         """Test the collection and update workflow between collector and
         user."""
@@ -112,7 +112,7 @@ class TestDataUserAndCollector:
         assert len(buffer.data) == 1
         assert buffer.data[0] == self.SAMPLE_DATA
 
-    def test_timestamp_counting(self, data_user: DataUser[int, list[int]], mocker):
+    def test_timestamp_counting(self, data_user: DataUser[list[int]], mocker):
         """Test counting of data points added since a timestamp."""
         mock_time = mocker.patch("pamiq_core.time.time")
         collector = data_user._collector
@@ -130,7 +130,7 @@ class TestDataUserAndCollector:
         assert data_user.count_data_added_since(104.0) == 0
 
     def test_max_size_constraint(
-        self, data_user: DataUser[int, list[int]], buffer: MockDataBuffer[int], mocker
+        self, data_user: DataUser[list[int]], buffer: MockDataBuffer[int], mocker
     ):
         """Test maximum size constraint is respected."""
         mock_time = mocker.patch("pamiq_core.time.time")
@@ -146,7 +146,7 @@ class TestDataUserAndCollector:
         assert len(buffer.data) == self.MAX_SIZE
 
     def test_public_interface_for_data_access(
-        self, data_user: DataUser[int, list[int]], mocker
+        self, data_user: DataUser[list[int]], mocker
     ):
         """Test the public interfaces for accessing collected data."""
         mock_time = mocker.patch("pamiq_core.time.time")
@@ -165,7 +165,7 @@ class TestDataUserAndCollector:
         # Test public len() interface
         assert len(data_user) == 1
 
-    def test_implict_update(self, data_user: DataUser[int, list[int]], mocker):
+    def test_implict_update(self, data_user: DataUser[list[int]], mocker):
         """Test the public interfaces for accessing collected data."""
         mock_time = mocker.patch("pamiq_core.time.time")
         mock_time.return_value = 100.0
@@ -181,7 +181,7 @@ class TestDataUserAndCollector:
 
     def test_save_and_load_state(
         self,
-        data_user: DataUser[int, list[int]],
+        data_user: DataUser[list[int]],
         mocker,
         buffer: MockDataBuffer[int],
         tmp_path: Path,

--- a/tests/pamiq_core/data/test_interface.py
+++ b/tests/pamiq_core/data/test_interface.py
@@ -2,97 +2,96 @@ from pathlib import Path
 
 import pytest
 
-from pamiq_core.data.interface import DataUser, TimestampingQueuesDict
+from pamiq_core.data.interface import DataUser, TimestampingQueue
 from pamiq_core.state_persistence import PersistentStateMixin
 
 from .helpers import MockDataBuffer
 
 
-class TestTimestampingQueuesDict:
-    """Test suite for TimestampingQueuesDict class."""
+class TestTimestampingQueue:
+    """Test suite for TimestampingQueue class."""
 
-    QUEUE_NAMES = ["state", "action", "reward"]
     MAX_LENGTH = 5
-    SAMPLE_DATA = {"state": [1.0, 2.0, 3.0], "action": [0, 1], "reward": 1.0}
+    SAMPLE_DATA = 42
 
     @pytest.fixture
-    def queues_dict(self) -> TimestampingQueuesDict:
-        """Fixture providing TimestampingQueuesDict instance."""
-        return TimestampingQueuesDict(self.QUEUE_NAMES, self.MAX_LENGTH)
+    def queue(self) -> TimestampingQueue[int]:
+        """Fixture providing TimestampingQueue instance."""
+        return TimestampingQueue[int](self.MAX_LENGTH)
 
-    def test_append_and_popleft(self, queues_dict: TimestampingQueuesDict, mocker):
+    def test_append_and_popleft(self, queue: TimestampingQueue[int], mocker):
         """Test append and popleft methods using only public interfaces."""
         mock_time = mocker.patch("pamiq_core.time.time")
         mock_time.return_value = 123.456
 
         # Verify empty initially
-        assert len(queues_dict) == 0
+        assert len(queue) == 0
 
         # Test append
-        queues_dict.append(self.SAMPLE_DATA)
-        assert len(queues_dict) == 1
+        queue.append(self.SAMPLE_DATA)
+        assert len(queue) == 1
 
         # Test popleft - verify we get the expected data and timestamp
-        data, timestamp = queues_dict.popleft()
+        data, timestamp = queue.popleft()
         assert data == self.SAMPLE_DATA
         assert timestamp == 123.456
-        assert len(queues_dict) == 0
+        assert len(queue) == 0
 
-    def test_append_multiple_items(self, queues_dict: TimestampingQueuesDict):
+    def test_append_multiple_items(self, queue: TimestampingQueue[int]):
         """Test appending multiple items and length tracking."""
         # Append multiple items
         for i in range(3):
-            queues_dict.append(self.SAMPLE_DATA)
-            assert len(queues_dict) == i + 1
+            queue.append(i)
+            assert len(queue) == i + 1
 
         # Verify popleft returns them in order
-        for _ in range(3):
-            queues_dict.popleft()
+        for i in range(3):
+            data, _ = queue.popleft()
+            assert data == i
 
         # Verify empty after popping all items
-        assert len(queues_dict) == 0
+        assert len(queue) == 0
 
-    def test_max_length_constraint(self, queues_dict: TimestampingQueuesDict):
+    def test_max_length_constraint(self, queue: TimestampingQueue[int]):
         """Test maximum length constraint using only public interfaces."""
         # Fill beyond max capacity
-        for _ in range(self.MAX_LENGTH + 2):
-            queues_dict.append(self.SAMPLE_DATA)
+        for i in range(self.MAX_LENGTH + 2):
+            queue.append(i)
 
         # Verify length is capped at MAX_LENGTH
-        assert len(queues_dict) == self.MAX_LENGTH
+        assert len(queue) == self.MAX_LENGTH
 
         # Verify we can pop exactly MAX_LENGTH items
         for _ in range(self.MAX_LENGTH):
-            queues_dict.popleft()
+            queue.popleft()
 
         # Verify empty after popping all items
-        assert len(queues_dict) == 0
+        assert len(queue) == 0
 
-    def test_empty_popleft(self, queues_dict: TimestampingQueuesDict):
-        """Test popleft from empty queues raises IndexError."""
+    def test_empty_popleft(self, queue: TimestampingQueue[int]):
+        """Test popleft from empty queue raises IndexError."""
         with pytest.raises(IndexError):
-            queues_dict.popleft()
+            queue.popleft()
 
 
 class TestDataUserAndCollector:
     """Integration test suite for DataUser and DataCollector."""
 
-    COLLECTING_NAMES = ["state", "action", "reward"]
     MAX_SIZE = 5
-    SAMPLE_DATA = {"state": [1.0, 2.0], "action": 1, "reward": 0.5}
+    SAMPLE_DATA = 42
 
     @pytest.fixture
-    def buffer(self) -> MockDataBuffer:
+    def buffer(self) -> MockDataBuffer[int]:
         """Fixture providing mock buffer instance."""
-        return MockDataBuffer(self.COLLECTING_NAMES, self.MAX_SIZE)
+        return MockDataBuffer[int](self.MAX_SIZE)
 
     @pytest.fixture
-    def data_user(self, buffer: MockDataBuffer) -> DataUser:
+    def data_user(self, buffer: MockDataBuffer[int]) -> DataUser[int, list[int]]:
         """Fixture providing DataUser instance."""
         return DataUser(buffer)
 
     def test_basic_collection_and_update(
-        self, data_user: DataUser, buffer: MockDataBuffer, mocker
+        self, data_user: DataUser[int, list[int]], buffer: MockDataBuffer[int], mocker
     ):
         """Test the collection and update workflow between collector and
         user."""
@@ -113,15 +112,15 @@ class TestDataUserAndCollector:
         assert len(buffer.data) == 1
         assert buffer.data[0] == self.SAMPLE_DATA
 
-    def test_timestamp_counting(self, data_user: DataUser, mocker):
+    def test_timestamp_counting(self, data_user: DataUser[int, list[int]], mocker):
         """Test counting of data points added since a timestamp."""
         mock_time = mocker.patch("pamiq_core.time.time")
         collector = data_user._collector
 
         timestamps = [100.0, 101.0, 102.0, 103.0]
-        for t in timestamps:
+        for i, t in enumerate(timestamps):
             mock_time.return_value = t
-            collector.collect(self.SAMPLE_DATA)
+            collector.collect(i)
             data_user.update()
 
         # Test the public interface for timestamp-based counting
@@ -131,7 +130,7 @@ class TestDataUserAndCollector:
         assert data_user.count_data_added_since(104.0) == 0
 
     def test_max_size_constraint(
-        self, data_user: DataUser, buffer: MockDataBuffer, mocker
+        self, data_user: DataUser[int, list[int]], buffer: MockDataBuffer[int], mocker
     ):
         """Test maximum size constraint is respected."""
         mock_time = mocker.patch("pamiq_core.time.time")
@@ -140,13 +139,15 @@ class TestDataUserAndCollector:
         # Add more data than MAX_SIZE
         for i in range(self.MAX_SIZE + 2):
             mock_time.return_value = 100.0 + i
-            collector.collect(self.SAMPLE_DATA)
+            collector.collect(i)
             data_user.update()
 
         # Verify size is capped at MAX_SIZE
         assert len(buffer.data) == self.MAX_SIZE
 
-    def test_public_interface_for_data_access(self, data_user: DataUser, mocker):
+    def test_public_interface_for_data_access(
+        self, data_user: DataUser[int, list[int]], mocker
+    ):
         """Test the public interfaces for accessing collected data."""
         mock_time = mocker.patch("pamiq_core.time.time")
         mock_time.return_value = 100.0
@@ -157,20 +158,18 @@ class TestDataUserAndCollector:
 
         # Test public get_data() interface
         buffer_data = data_user.get_data()
-        assert isinstance(buffer_data, dict)
-        for key in self.COLLECTING_NAMES:
-            assert key in buffer_data
-            assert len(buffer_data[key]) == 1
-            assert buffer_data[key][0] == self.SAMPLE_DATA[key]
+        assert isinstance(buffer_data, list)
+        assert len(buffer_data) == 1
+        assert buffer_data[0] == self.SAMPLE_DATA
 
         # Test public len() interface
         assert len(data_user) == 1
 
     def test_save_and_load_state(
         self,
-        data_user: DataUser,
+        data_user: DataUser[int, list[int]],
         mocker,
-        buffer: MockDataBuffer,
+        buffer: MockDataBuffer[int],
         tmp_path: Path,
     ):
         """Test save_state and load_state methods of DataUser."""

--- a/tests/pamiq_core/data/test_interface.py
+++ b/tests/pamiq_core/data/test_interface.py
@@ -165,6 +165,20 @@ class TestDataUserAndCollector:
         # Test public len() interface
         assert len(data_user) == 1
 
+    def test_implict_update(self, data_user: DataUser[int, list[int]], mocker):
+        """Test the public interfaces for accessing collected data."""
+        mock_time = mocker.patch("pamiq_core.time.time")
+        mock_time.return_value = 100.0
+
+        # Collect and update data
+        data_user._collector.collect(self.SAMPLE_DATA)
+
+        # Test public get_data() interface
+        buffer_data = data_user.get_data()
+        assert isinstance(buffer_data, list)
+        assert len(buffer_data) == 1
+        assert buffer_data[0] == self.SAMPLE_DATA
+
     def test_save_and_load_state(
         self,
         data_user: DataUser[int, list[int]],

--- a/tests/pamiq_core/test_launcher.py
+++ b/tests/pamiq_core/test_launcher.py
@@ -49,9 +49,9 @@ class TestLaunch:
 
     @pytest.fixture
     def mock_buffer(self, mocker: MockerFixture):
-        """Create a mock DataBuffer with zero size."""
+        """Create a mock DataBuffer with zero queue size."""
         buf = mocker.MagicMock(DataBuffer)
-        buf.max_size = 0
+        buf.max_queue_size = 0
         return buf
 
     @pytest.fixture

--- a/tests/pamiq_core/test_testing.py
+++ b/tests/pamiq_core/test_testing.py
@@ -37,7 +37,7 @@ class TestConnectComponents:
     def mock_buffer(self, mocker: MockerFixture) -> DataBuffer:
         """Fixture for a mock data buffer."""
         buffer = mocker.MagicMock(spec=DataBuffer)
-        buffer.max_size = 0
+        buffer.max_queue_size = 0
         return buffer
 
     @pytest.fixture
@@ -220,14 +220,14 @@ class TestCreateMockBuffer:
         buffer = create_mock_buffer()
 
         # Verify buffer is correctly configured
-        assert buffer.max_size == 1
+        assert buffer.max_queue_size == 1
         assert isinstance(buffer, MagicMock)
         assert isinstance(buffer, DataBuffer)
 
-    def test_custom_max_size(self) -> None:
-        """Test create_mock_buffer with custom max_size."""
+    def test_custom_max_queue_size(self) -> None:
+        """Test create_mock_buffer with custom max_queue_size."""
         custom_size = 100
-        buffer = create_mock_buffer(max_size=custom_size)
+        buffer = create_mock_buffer(max_queue_size=custom_size)
 
-        # Verify buffer has the specified max_size
-        assert buffer.max_size == custom_size
+        # Verify buffer has the specified max_queue_size
+        assert buffer.max_queue_size == custom_size


### PR DESCRIPTION
# Pull Request

## 内容

#291 #292 

* StepData型を削除し、任意の型のデータを収集することができる構造としました。これにより、辞書ベース出ないデータ収集が可能になり、より柔軟なユースケースをサポートします。

* DataBufferのコンストラクタが大きく変更されました。
  * 辞書ベースのデータ保存を行わないため、`collecting_data_names`が削除されました。
  * `max_size`は実際にはDataCollectorのQueueサイズの決定のために使われていたため、正式に`max_queue_size`としたほか、`None`をサポートして無限に貯められるようにしました（Warningは出ます）

* 既存のバッファ実装(SequentialBufferなど）が辞書ベースではなくなりました。今まで存在した 辞書式のものは、 `Dict` prefixがついた形で扱えます。
  * RandomReplacementBufferのqueueサイズは、buffer の max size / 置換確率にして、バッファよりも大きく保存できるようにしています。（こうしないと捨てられる可能性が増えるため）
* DataUserの`get_data`メソッドが自動的に`update`を呼ぶようになりました。queueに溜まり続ける問題を回避します。

* ドキュメントを更新しました。 v0.4から0.5で破壊的な変更が生じるため、Migration 情報を追記済みです。 v1.0.0で削除します。

* VAE Torch のサンプル実装に調整をかけました。


全体的にシンプルかつ柔軟性を向上させる方向に進んだので、私は問題ないと考えています。アルファの時点で良かったなと。

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [ ] なし
- [x] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [x] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [x] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [x] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [x] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
