### PR TITLE
Buffer実装のDict類に関して、 `add`する際に `dict(data)`を行うことで shallow copy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pamiq-core"
-version = "0.5.0"
+version = "0.5.1"
 description = "Framework for building AI agents with real-time adaptive learning capabilities."
 license = {file = "LICENSE"}
 readme = "README.md"

--- a/src/pamiq_core/data/impls/random_replacement_buffer.py
+++ b/src/pamiq_core/data/impls/random_replacement_buffer.py
@@ -185,7 +185,7 @@ class DictRandomReplacementBuffer[T](DataBuffer[Mapping[str, T], dict[str, list[
 
         Other arguments are same as [`RandomReplacementBuffer`][pamiq_core.data.impls.RandomReplacementBuffer].
         """
-        self._buffer = RandomReplacementBuffer[Mapping[str, T]](
+        self._buffer = RandomReplacementBuffer[dict[str, T]](
             max_size, replace_probability, expected_survival_length
         )
         super().__init__(self._buffer.max_queue_size)
@@ -217,7 +217,7 @@ class DictRandomReplacementBuffer[T](DataBuffer[Mapping[str, T], dict[str, list[
             raise ValueError(
                 f"Data keys {set(data.keys())} do not match expected keys {self._keys}"
             )
-        return self._buffer.add(data)
+        return self._buffer.add(dict(data))
 
     @override
     def get_data(self) -> dict[str, list[T]]:

--- a/tests/pamiq_core/data/impls/test_random_replacement_buffer.py
+++ b/tests/pamiq_core/data/impls/test_random_replacement_buffer.py
@@ -351,3 +351,26 @@ class TestDictRandomReplacementBuffer:
 
         assert new_buffer.get_data() == buffer.get_data()
         assert len(new_buffer) == len(buffer)
+
+    def test_add_creates_shallow_copy(self):
+        """Test that add creates a shallow copy of the input dictionary."""
+        buffer = DictRandomReplacementBuffer[int](["x", "y"], max_size=5)
+
+        # Create original data
+        original_data = {"x": 1, "y": 2}
+
+        # Add to buffer
+        buffer.add(original_data)
+
+        # Modify original data by adding new key (which should not affect buffer)
+        original_data["z"] = 999
+        # Modify values
+        original_data["x"] = 999
+        original_data["y"] = 999
+
+        # Get data from buffer
+        buffer_data = buffer.get_data()
+
+        # Buffer should have the original values
+        assert buffer_data == {"x": [1], "y": [2]}
+        assert "z" not in buffer_data

--- a/tests/pamiq_core/data/impls/test_sequential_buffer.py
+++ b/tests/pamiq_core/data/impls/test_sequential_buffer.py
@@ -208,3 +208,26 @@ class TestDictSequentialBuffer:
 
         assert new_buffer.get_data() == buffer.get_data()
         assert len(new_buffer) == len(buffer)
+
+    def test_add_creates_shallow_copy(self):
+        """Test that add creates a shallow copy of the input dictionary."""
+        buffer = DictSequentialBuffer[int](["x", "y"], max_size=5)
+
+        # Create original data
+        original_data = {"x": 1, "y": 2}
+
+        # Add to buffer
+        buffer.add(original_data)
+
+        # Modify original data by adding new key (which should not affect buffer)
+        original_data["z"] = 999
+        # Modify values
+        original_data["x"] = 999
+        original_data["y"] = 999
+
+        # Get data from buffer
+        buffer_data = buffer.get_data()
+
+        # Buffer should have the original values
+        assert buffer_data == {"x": [1], "y": [2]}
+        assert "z" not in buffer_data

--- a/uv.lock
+++ b/uv.lock
@@ -708,7 +708,7 @@ wheels = [
 
 [[package]]
 name = "pamiq-core"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
# Pull Request

## 内容

データをバッファに追加する際に、shallow copyを行っていないため 他の実験リポジトリで データ上書きの問題が発生しました。
そのリポジトリの実装の責任ですが、同じようなミスを起こさないようにするために、shallow copyを pamiq coreでも行うこととします。

<!-- 変更の目的・内容 もしくは 関連する Issue 番号 -->

<!-- ビューの変更がある場合はスクショによる比較などがあるとわかりやすい -->

## 他のコード・機能への影響

- [ ] なし
- [ ] あり

<!-- ある場合は記述 -->

<!-- この関数を変更したのでこの機能にも影響がある、など -->

## Submit前の確認項目

<!-- PRをSubmitする前に確認する項目 -->

- [ ] タイトルは一目でわかるようにし、説明文は PR を簡潔に説明するようにしましたか?
- [ ] あなたの PR が、異なる変更を束ねたものではなく、ひとつのことだけを行うものであることを確認しましたか?
- [ ] この PR で導入されたすべての変更点を記述、リストアップしましたか?
- [ ] PR を`make run`コマンドでローカルでテストしましたか?

## 補足

<!-- レビューをする際に見てほしい点、ローカル環境で試す際の注意点、など -->
